### PR TITLE
Correction de l'affichage en double des cartes pendant le drag & drop

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -133,9 +133,11 @@ function love.mousepressed(x, y, button)
     
     -- Clic sur une carte en main
     if button == 1 then
-        local card = cardSystem:getCardAt(x, y)
+        local card, cardIndex = cardSystem:getCardAt(x, y)
         if card then
-            dragDrop:startDrag(card, x, y)
+            -- Marquer la carte comme étant en cours de déplacement
+            cardSystem:setDraggingCard(cardIndex)
+            dragDrop:startDrag(card, cardIndex, x, y)
         end
     end
 end

--- a/src/systems/card_system.lua
+++ b/src/systems/card_system.lua
@@ -9,6 +9,7 @@ function CardSystem.new()
     self.deck = {}
     self.hand = {}
     self.discardPile = {}
+    self.draggingCardIndex = nil -- Indice de la carte en cours de déplacement
     
     -- Initialisation du deck avec cartes de base
     self:initializeDeck()
@@ -103,6 +104,15 @@ function CardSystem:playCard(cardIndex, garden, x, y)
         if garden:placePlant(plant, x, y) then
             table.remove(self.hand, cardIndex)
             table.insert(self.discardPile, card)
+            
+            -- Réinitialiser l'indice de la carte en drag si c'était celle-là
+            if self.draggingCardIndex == cardIndex then
+                self.draggingCardIndex = nil
+            elseif self.draggingCardIndex and self.draggingCardIndex > cardIndex then
+                -- Ajuster l'indice si une carte avant celle en déplacement est supprimée
+                self.draggingCardIndex = self.draggingCardIndex - 1
+            end
+            
             return true
         end
     end
@@ -149,16 +159,19 @@ function CardSystem:drawHand()
     
     -- Calculer la position des cartes en arc
     for i, card in ipairs(self.hand) do
-        local angle = (i - (#self.hand + 1) / 2) * 0.1
-        local x = screenWidth / 2 + angle * 200
-        local y = handY + math.abs(angle) * 50
-        
-        -- Stocker la position pour le drag & drop
-        card.x = x
-        card.y = y
-        
-        -- Dessiner la carte
-        self:renderCard(card, x, y)
+        -- Ignorer la carte en cours de déplacement
+        if i ~= self.draggingCardIndex then
+            local angle = (i - (#self.hand + 1) / 2) * 0.1
+            local x = screenWidth / 2 + angle * 200
+            local y = handY + math.abs(angle) * 50
+            
+            -- Stocker la position pour le drag & drop
+            card.x = x
+            card.y = y
+            
+            -- Dessiner la carte
+            self:renderCard(card, x, y)
+        end
     end
 end
 
@@ -172,6 +185,16 @@ function CardSystem:getCardAt(x, y)
         end
     end
     return nil
+end
+
+-- Définir la carte en cours de déplacement
+function CardSystem:setDraggingCard(index)
+    self.draggingCardIndex = index
+end
+
+-- Réinitialiser l'état de déplacement
+function CardSystem:resetDragging()
+    self.draggingCardIndex = nil
 end
 
 return CardSystem

--- a/src/ui/drag_drop.lua
+++ b/src/ui/drag_drop.lua
@@ -6,6 +6,7 @@ function DragDrop.new()
     local self = setmetatable({}, DragDrop)
     self.dragging = nil -- carte en cours de déplacement
     self.originalCard = nil -- sauvegarde des informations de la carte
+    self.cardIndex = nil -- indice de la carte dans la main
     self.dragOffsetX = 0
     self.dragOffsetY = 0
     self.targetCell = nil -- cellule cible surbrillance
@@ -13,9 +14,10 @@ function DragDrop.new()
     return self
 end
 
-function DragDrop:startDrag(card, x, y)
-    -- Sauvegarder la carte originale
+function DragDrop:startDrag(card, cardIndex, x, y)
+    -- Sauvegarder la carte originale et son indice
     self.originalCard = card
+    self.cardIndex = cardIndex
     
     -- Créer une copie pour le drag & drop
     self.dragging = {}
@@ -60,18 +62,8 @@ function DragDrop:stopDrag(garden, cardSystem)
                 
                 -- Tenter de placer la plante
                 if not garden.grid[y][x].plant then
-                    local cardIndex = nil
-                    
-                    -- Trouver l'index de la carte dans la main
-                    for i, handCard in ipairs(cardSystem.hand) do
-                        if handCard == card then
-                            cardIndex = i
-                            break
-                        end
-                    end
-                    
-                    if cardIndex then
-                        placed = cardSystem:playCard(cardIndex, garden, x, y)
+                    if self.cardIndex then
+                        placed = cardSystem:playCard(self.cardIndex, garden, x, y)
                     end
                 end
                 
@@ -81,8 +73,15 @@ function DragDrop:stopDrag(garden, cardSystem)
         if placed then break end
     end
     
+    -- Réinitialiser l'état du système de cartes
+    if not placed and cardSystem then
+        cardSystem:resetDragging()
+    end
+    
+    -- Réinitialiser l'état de drag & drop
     self.dragging = nil
     self.originalCard = nil
+    self.cardIndex = nil
     self.targetCell = nil
     
     return placed


### PR DESCRIPTION
## Problème
Actuellement, quand une carte est déplacée (drag & drop), elle reste visible à la fois dans la main du joueur et sous le curseur, créant une duplication visuelle qui peut être déroutante.

## Solution proposée
Cette modification coordonne le système de cartes et le système de drag & drop pour résoudre ce problème :

1. **Suivi des cartes en déplacement** : Le CardSystem garde une trace de l'indice de la carte actuellement déplacée via `draggingCardIndex`.
2. **Masquage des cartes déplacées** : Lors du rendu de la main, les cartes en cours de déplacement sont ignorées.
3. **Communication entre systèmes** : Le système de drag & drop informe le système de cartes des actions de l'utilisateur.

## Changements clés
1. Dans `card_system.lua` :
   - Ajout de `draggingCardIndex` pour suivre la carte en déplacement
   - Modification de `drawHand()` pour ignorer les cartes en déplacement
   - Ajout de méthodes `setDraggingCard()` et `resetDragging()`

2. Dans `drag_drop.lua` :
   - Modification de `startDrag()` pour stocker l'indice de la carte
   - Mise à jour de `stopDrag()` pour coordonner avec le système de cartes

3. Dans `main.lua` :
   - Transmission de l'indice de la carte au système de drag & drop
   - Notification au système de cartes du début du déplacement

## Test
Cette modification peut être testée en :
- Saisissant une carte et en la déplaçant
- Vérifiant qu'elle n'apparaît qu'une seule fois (sous le curseur, pas dans la main)
- Vérifiant que le placement dans le potager fonctionne toujours correctement
