### PR TITLE
Animation de retour en ligne droite des cartes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Ce document liste les modifications majeures apportées au projet depuis sa création.
 
+## [Non publié] - 2025-03-15
+
+### Amélioration
+- **Interface utilisateur**
+  - Animation de retour en ligne droite des cartes après un drag & drop non réussi
+  - Meilleur retour visuel pour les actions de drag & drop
+
 ## [Non publié] - 2025-03-14
 
 ### Ajout


### PR DESCRIPTION
## Description
Cette pull request améliore l'animation des cartes lors d'un drag & drop non réussi. Désormais, lorsqu'une carte est relâchée sur une position non valide, elle revient à sa position d'origine dans la main du joueur en suivant une trajectoire en ligne droite au lieu de simplement disparaître et réapparaître.

## Modifications apportées
- Ajout d'un système d'animation de retour en ligne droite pour les cartes
- Conservation de l'animation d'échelle existante, mais séquencée après l'animation de position
- Amélioration de la gestion des événements pendant les animations
- Optimisation du code pour une meilleure lisibilité et maintenabilité

## Comportement précédent vs nouveau
- **Avant** : La carte disparaissait immédiatement et réapparaissait dans la main
- **Après** : La carte retourne en ligne droite à sa position dans la main, suivie d'une animation d'échelle

## Éléments testés
- Animation fluide du retour des cartes
- Comportement correct lors de tentatives consécutives de drag & drop
- Maintien de la fonctionnalité de placement des cartes

## Captures d'écran
N/A (changement comportemental difficile à illustrer par une image fixe)

## Pour valider cette PR
1. Essayer de faire glisser une carte sur une cellule déjà occupée ou en dehors du potager
2. Observer l'animation de retour fluide en ligne droite vers la position d'origine