### PR TITLE
Correction du scintillement des cartes sous le curseur

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Ce document liste les modifications majeures apportées au projet depuis sa cré
 ### Amélioration
 - **Interface utilisateur**
   - Animation de retour en ligne droite des cartes après un drag & drop non réussi
+  - Correction du scintillement des cartes sous le curseur lors du retour à la main
   - Meilleur retour visuel pour les actions de drag & drop
 
 ## [Non publié] - 2025-03-14


### PR DESCRIPTION
## Description
Cette pull request corrige un problème de scintillement où la carte réapparaissait brièvement sous le curseur de la souris lors de l'animation de retour dans la main.

## Problème
Lorsque l'animation de retour en ligne droite ramène la carte vers sa position originale dans la main, si le curseur de la souris reste immobile, la carte passe sous le curseur et devient momentanément visible à cet endroit, créant un effet de scintillement indésirable.

## Solution
- Ajout d'un mécanisme qui détecte quand la carte en animation passe près du curseur
- Masquage temporaire de la carte lorsqu'elle passe près du curseur de la souris, en particulier vers la fin de l'animation
- Restauration de la visibilité une fois l'animation terminée ou si le curseur n'est plus sur la trajectoire de la carte

## Changements techniques
1. Ajout d'une propriété `visible` au système de drag & drop pour contrôler l'affichage
2. Calcul de la distance entre le curseur et la carte pendant l'animation
3. Masquage temporaire de la carte quand cette distance est faible et que l'animation est presque terminée
4. Vérification dans la méthode `draw()` que la carte est visible avant de la dessiner

## Test
Pour tester cette correction :
1. Glisser une carte vers un emplacement non valide (sur une case occupée ou en dehors du potager)
2. Gardez le curseur immobile pendant que la carte retourne à sa position d'origine
3. Vérifiez qu'il n'y a plus de scintillement lorsque la carte passe sous le curseur