### PR TITLE
Solution radicale au problème de scintillement des cartes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Ce document liste les modifications majeures apportées au projet depuis sa cré
 ### Amélioration
 - **Interface utilisateur**
   - Animation de retour en ligne droite des cartes après un drag & drop non réussi
-  - Correction du scintillement des cartes sous le curseur lors du retour à la main
+  - Correction complète du scintillement des cartes en masquant la carte d'origine pendant le retour
   - Meilleur retour visuel pour les actions de drag & drop
 
 ## [Non publié] - 2025-03-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Ce document liste les modifications majeures apportées au projet depuis sa cré
 ### Amélioration
 - **Interface utilisateur**
   - Animation de retour en ligne droite des cartes après un drag & drop non réussi
+  - Correction du scintillement des cartes sous le curseur lors du retour à la main
   - Meilleur retour visuel pour les actions de drag & drop
 
 ## [Non publié] - 2025-03-14

--- a/src/systems/card_system.lua
+++ b/src/systems/card_system.lua
@@ -18,6 +18,7 @@ function CardSystem.new()
     self.hand = {}
     self.discardPile = {}
     self.draggingCardIndex = nil -- Indice de la carte en cours de déplacement
+    self.cardInReturnAnimation = nil -- Indice de la carte en cours d'animation de retour
     
     -- Initialisation du deck avec cartes de base
     self:initializeDeck()
@@ -121,6 +122,14 @@ function CardSystem:playCard(cardIndex, garden, x, y)
                 self.draggingCardIndex = self.draggingCardIndex - 1
             end
             
+            -- Réinitialiser aussi l'indice de la carte en animation de retour si nécessaire
+            if self.cardInReturnAnimation == cardIndex then
+                self.cardInReturnAnimation = nil
+            elseif self.cardInReturnAnimation and self.cardInReturnAnimation > cardIndex then
+                -- Ajuster l'indice si une carte avant celle en animation est supprimée
+                self.cardInReturnAnimation = self.cardInReturnAnimation - 1
+            end
+            
             return true
         end
     end
@@ -176,8 +185,8 @@ function CardSystem:drawHand()
     
     -- Calculer la position des cartes en arc
     for i, card in ipairs(self.hand) do
-        -- Ignorer la carte en cours de déplacement
-        if i ~= self.draggingCardIndex then
+        -- Ignorer la carte en cours de déplacement ou en animation de retour
+        if i ~= self.draggingCardIndex and i ~= self.cardInReturnAnimation then
             local angle = (i - (#self.hand + 1) / 2) * 0.1
             local x = screenWidth / 2 + angle * 270 -- Ajusté pour les cartes plus grandes
             local y = handY + math.abs(angle) * 70  -- Ajusté pour les cartes plus grandes
@@ -195,10 +204,13 @@ end
 -- Fonction pour savoir si un point est sur une carte
 function CardSystem:getCardAt(x, y)
     for i = #self.hand, 1, -1 do -- Regarder de haut en bas
-        local card = self.hand[i]
-        if x >= card.x - CARD_WIDTH/2 and x <= card.x + CARD_WIDTH/2 and
-           y >= card.y - CARD_HEIGHT/2 and y <= card.y + CARD_HEIGHT/2 then
-            return card, i
+        -- Ignorer les cartes en animation de retour
+        if i ~= self.cardInReturnAnimation then
+            local card = self.hand[i]
+            if x >= card.x - CARD_WIDTH/2 and x <= card.x + CARD_WIDTH/2 and
+               y >= card.y - CARD_HEIGHT/2 and y <= card.y + CARD_HEIGHT/2 then
+                return card, i
+            end
         end
     end
     return nil
@@ -207,6 +219,16 @@ end
 -- Définir la carte en cours de déplacement
 function CardSystem:setDraggingCard(index)
     self.draggingCardIndex = index
+end
+
+-- Définir la carte en cours d'animation de retour
+function CardSystem:setCardInReturnAnimation(index)
+    self.cardInReturnAnimation = index
+end
+
+-- Réinitialiser la carte en animation de retour
+function CardSystem:clearCardInReturnAnimation()
+    self.cardInReturnAnimation = nil
 end
 
 -- Réinitialiser l'état de déplacement

--- a/src/ui/drag_drop.lua
+++ b/src/ui/drag_drop.lua
@@ -47,7 +47,8 @@ function DragDrop.new()
         targetX = 0,
         targetY = 0,
         cardSystem = nil, -- Référence au système de cartes pour cacher la carte originale
-        progress = 0
+        progress = 0,
+        callback = nil
     }
     
     return self
@@ -251,6 +252,11 @@ function DragDrop:stopDrag(garden, cardSystem)
                 self.originalCard = nil
                 self.cardIndex = nil
                 self.targetCell = nil
+                
+                -- S'assurer que la carte n'est plus marquée comme en animation de retour
+                if cardSystem then
+                    cardSystem:clearCardInReturnAnimation()
+                end
             end)
         end)
         


### PR DESCRIPTION
## Description
Cette pull request résout de manière radicale le problème de scintillement qui se produisait lorsqu'une carte était relâchée et retournait à sa position dans la main du joueur. La solution implique une refonte complète du mécanisme d'animation de retour des cartes.

## Problème initial
Lors de l'animation de retour d'une carte vers sa position d'origine dans la main du joueur, la carte scintillait sous le curseur de la souris, créant un effet visuel indésirable. Ce problème était dû au fait que la carte animée et la carte d'origine étaient toutes deux affichées simultanément.

## Solution implémentée
La solution radicale mise en œuvre ici consiste à masquer complètement la carte d'origine pendant toute la durée de l'animation de retour. Pour cela :

1. **Système de coordination entre composants** : Ajout d'un mécanisme permettant au système de drag & drop de communiquer avec le système de cartes pour indiquer quelle carte est en cours d'animation.

2. **Exclusion des cartes animées** : Le système de cartes ignore maintenant les cartes marquées comme étant en animation lors du rendu de la main du joueur.

3. **Gestion propre des états** : Des méthodes dédiées ont été ajoutées pour marquer et démarquer les cartes en animation, garantissant une gestion cohérente de l'état visuel des cartes.

4. **Nettoyage amélioré** : Garantie que tous les états sont correctement réinitialisés à la fin des animations et lors de la suppression des cartes.

## Impact sur le code existant
- Ajout de nouveaux attributs et méthodes au système de cartes
- Modification de la méthode de rendu des cartes en main
- Mise à jour du système drag & drop pour communiquer l'état d'animation au système de cartes
- Aucun impact sur les autres parties du code ou sur l'API publique de ces composants

## Tests effectués
- Glisser-déposer d'une carte sur une case vide (placement normal)
- Glisser-déposer d'une carte sur une case déjà occupée (retour à la main)
- Glisser-déposer d'une carte en dehors du potager (retour à la main)
- Test avec curseur immobile pendant le retour de la carte (plus de scintillement)
- Test de drag & drop répétés pour vérifier la cohérence des états

## Visuellement
Avant : La carte scintillait sous le curseur lors du retour à la main
Après : Animation fluide sans aucun scintillement