### PR TITLE
Correction du double affichage des cartes lors du retour à la main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,15 @@ Ce document liste les modifications majeures apportées au projet depuis sa cré
 
 ## [Non publié] - 2025-03-15
 
+### Corrections
+- **Interface utilisateur**
+  - Correction du problème de double affichage des cartes lors du retour à la main
+  - Refonte du système d'animation des cartes avec séparation des animations de position et d'échelle
+  - Élimination du scintillement visuel lors du relâchement d'une carte
+
 ### Amélioration
 - **Interface utilisateur**
   - Animation de retour en ligne droite des cartes après un drag & drop non réussi
-  - Correction complète du scintillement des cartes en masquant la carte d'origine pendant le retour
   - Meilleur retour visuel pour les actions de drag & drop
 
 ## [Non publié] - 2025-03-14


### PR DESCRIPTION
## Description
Cette pull request corrige un problème spécifique de double affichage des cartes lors de l'animation de retour à la main après un drag & drop non réussi. Le problème se produisait dans une circonstance particulière : lorsque l'utilisateur relâchait une carte sans déplacer la souris, la carte revenait correctement dans la main mais réapparaissait brièvement à sa position initiale sous le curseur.

## Analyse du problème
Après analyse détaillée, le problème provenait de la façon dont les animations étaient chaînées :
1. Une première animation déplaçait la carte de sa position actuelle vers sa position finale dans la main
2. Une fois cette animation terminée, une seconde animation était lancée pour redimensionner la carte
3. Cette seconde animation **réinitialisait la position de la carte** à l'emplacement du curseur, provoquant l'effet de double affichage

## Solution implémentée
La solution consiste à séparer clairement les animations de déplacement et de redimensionnement :
1. **Nouvelle classe d'animation** : Ajout d'une animation spécifique `finalScaleAnimation` qui gère uniquement le redimensionnement à la position finale (sans déplacer la carte)
2. **Chaînage correct des animations** : La carte est d'abord déplacée en ligne droite vers sa position finale, puis redimensionnée sans changer sa position
3. **Mécanisme d'échelle unifié** : La méthode `draw()` détermine dynamiquement quelle échelle utiliser selon l'animation active

## Impact sur le code
- Ajout d'un nouveau système d'animation dans `DragDrop`
- Modification du chaînage des animations lors du retour des cartes
- Unification du code de rendu pour supporter les deux types d'animations d'échelle
- Aucun impact sur les autres parties du code ou sur l'API publique

## Tests effectués
- Glisser-déposer d'une carte sur une case vide (placement normal)
- Glisser-déposer d'une carte sur une case déjà occupée (retour à la main)
- Test explicite du cas problématique : glisser légèrement une carte, relâcher sans bouger le curseur
- Vérification que la carte ne réapparaît plus sous le curseur lors du retour à la main
- Tests multiples pour vérifier la robustesse de la solution dans diverses conditions