### PR TITLE
Correction des bugs de pioche et d'affichage introduits par les améliorations Zatopek

### DIFF
--- a/src/states/game_state.lua
+++ b/src/states/game_state.lua
@@ -4,6 +4,7 @@ local Constants = require('src.utils.constants')
 local Config = require('src.utils.config')
 local DependencyContainer = require('src.utils.dependency_container')
 local Localization = require('src.utils.localization')
+local CardSystem = require('src.systems.card_system')
 
 local GameState = {}
 GameState.__index = GameState
@@ -39,19 +40,57 @@ function GameState:draw()
     -- Convertir constante en texte pour affichage via le système de localisation
     local seasonText = Localization.getText(self.currentSeason)
     
-    -- Interface utilisateur
-    love.graphics.setColor(1, 1, 1)
-    love.graphics.print(Localization.getText("ui.tour") .. ": " .. self.currentTurn .. "/" .. self.maxTurns, 10, 10)
-    love.graphics.print(Localization.getText("ui.saison") .. ": " .. seasonText, 150, 10)
-    love.graphics.print(Localization.getText("ui.soleil") .. ": " .. self.sunDieValue, 300, 10)
-    love.graphics.print(Localization.getText("ui.pluie") .. ": " .. self.rainDieValue, 400, 10)
-    love.graphics.print(Localization.getText("ui.score") .. ": " .. self.score .. "/" .. self.objective, 500, 10)
+    -- Interface utilisateur - haut de l'écran
+    love.graphics.setColor(0.9, 0.95, 0.9)
+    love.graphics.rectangle("fill", 10, 10, 580, 40)
+    love.graphics.setColor(0, 0, 0)
+    love.graphics.print(Localization.getText("ui.saison") .. ": " .. seasonText .. " (" .. math.ceil(self.currentTurn/2) .. "/4)", 30, 25)
     
-    -- Dessiner bouton fin de tour
+    -- Indicateur de tour
+    love.graphics.setColor(0.8, 0.9, 0.95)
+    love.graphics.rectangle("fill", 10, 60, 580, 30)
+    love.graphics.setColor(0.4, 0.4, 0.4)
+    love.graphics.line(50, 75, 550, 75)
+    
+    -- Cercles des tours
+    for i = 1, 8 do
+        local x = 50 + (i-1) * 500/7
+        if i == self.currentTurn then
+            love.graphics.setColor(0.4, 0.4, 0.4)
+            love.graphics.circle("fill", x, 75, 8)
+        else
+            love.graphics.setColor(0.4, 0.4, 0.4)
+            love.graphics.circle("line", x, 75, 8)
+        end
+    end
+    
+    -- Dés et bouton
+    love.graphics.setColor(0.8, 0.9, 0.95)
+    love.graphics.rectangle("fill", 10, 100, 580, 50)
+    
+    -- Dé soleil
+    love.graphics.setColor(1, 0.8, 0)
+    love.graphics.rectangle("fill", 240, 105, 40, 40, 6)
+    love.graphics.setColor(0, 0, 0)
+    love.graphics.print(self.sunDieValue, 255, 115)
+    love.graphics.print(Localization.getText("ui.soleil"), 245, 130)
+    
+    -- Dé pluie
+    love.graphics.setColor(0.6, 0.8, 1)
+    love.graphics.rectangle("fill", 310, 105, 40, 40, 6)
+    love.graphics.setColor(0, 0, 0)
+    love.graphics.print(self.rainDieValue, 325, 115)
+    love.graphics.print(Localization.getText("ui.pluie"), 317, 130)
+    
+    -- Bouton fin de tour
     love.graphics.setColor(0.6, 0.8, 0.6)
     love.graphics.rectangle("fill", 480, 110, 80, 30, 5)
-    love.graphics.setColor(0.2, 0.2, 0.2)
-    love.graphics.print(Localization.getText("ui.fin_tour"), 487, 115)
+    love.graphics.setColor(0, 0, 0)
+    love.graphics.print(Localization.getText("ui.fin_tour"), 487, 120)
+    
+    -- Score
+    love.graphics.setColor(0, 0, 0)
+    love.graphics.print(Localization.getText("ui.score") .. ": " .. self.score .. "/" .. self.objective, 10, 160)
 end
 
 function GameState:mousepressed(x, y, button)
@@ -102,8 +141,21 @@ function GameState:applyWeather()
 end
 
 function GameState:nextTurn()
+    -- Récupérer le CardSystem global (fixé par rapport à la version précédente)
+    local cardSystem = _G.cardSystem
+    
+    -- Piocher une carte
+    if cardSystem then
+        cardSystem:drawCard()
+    end
+    
     -- Passer au tour suivant
     self.currentTurn = self.currentTurn + 1
+    
+    -- Vérifier fin de partie
+    if self.currentTurn > self.maxTurns then
+        self.currentTurn = 1
+    end
     
     -- Mettre à jour la saison
     local season = math.ceil(self.currentTurn / 2)

--- a/src/states/game_state.lua
+++ b/src/states/game_state.lua
@@ -4,7 +4,6 @@ local Constants = require('src.utils.constants')
 local Config = require('src.utils.config')
 local DependencyContainer = require('src.utils.dependency_container')
 local Localization = require('src.utils.localization')
-local CardSystem = require('src.systems.card_system')
 
 local GameState = {}
 GameState.__index = GameState
@@ -141,8 +140,17 @@ function GameState:applyWeather()
 end
 
 function GameState:nextTurn()
-    -- Récupérer le CardSystem global (fixé par rapport à la version précédente)
-    local cardSystem = _G.cardSystem
+    local cardSystem
+    
+    -- Essayer d'abord d'utiliser l'injecteur de dépendances
+    local success = pcall(function()
+        cardSystem = DependencyContainer.resolve("CardSystem")
+    end)
+    
+    -- Si échec, utiliser la référence globale directement
+    if not success or not cardSystem then
+        cardSystem = _G.cardSystem
+    end
     
     -- Piocher une carte
     if cardSystem then

--- a/src/utils/dependency_setup.lua
+++ b/src/utils/dependency_setup.lua
@@ -22,7 +22,16 @@ function DependencySetup.initialize()
         return CardRenderer.new()
     end)
     
-    -- D'autres dépendances peuvent être ajoutées ici
+    -- Enregistrer les systèmes globaux après leur initialisation
+    DependencyContainer.register("CardSystem", function()
+        -- Utilisation de la référence globale
+        return _G.cardSystem
+    end)
+    
+    DependencyContainer.register("Garden", function()
+        -- Utilisation de la référence globale via GameState
+        return _G.gameState and _G.gameState.garden
+    end)
     
     return true
 end

--- a/src/utils/localization.lua
+++ b/src/utils/localization.lua
@@ -37,7 +37,17 @@ Localization.translations = {
         ["ui.pluie"] = "Pluie",
         ["ui.score"] = "Score",
         ["ui.fin_tour"] = "Fin du tour",
-        ["ui.points"] = "pts"
+        ["ui.points"] = "pts",
+        
+        -- Textes d'erreur et d'information
+        ["error.dependency_not_found"] = "Dépendance non trouvée",
+        ["info.turn_completed"] = "Tour terminé",
+        
+        -- Nom des saisons au format numérique
+        ["season.1"] = "Printemps",
+        ["season.2"] = "Été",
+        ["season.3"] = "Automne",
+        ["season.4"] = "Hiver"
     }
     -- Support pour d'autres langues à ajouter ici
 }


### PR DESCRIPTION
## Description
Cette PR corrige les problèmes introduits par les améliorations Zatopek précédentes, tout en préservant les avantages architecturaux.

### Problèmes corrigés
1. **Pioche de cartes** - Le système ne piochait plus de carte à la fin de chaque tour car la méthode `nextTurn()` avait perdu cette fonctionnalité
2. **Affichage des tours** - L'interface visuelle des tours a été restaurée pour montrer clairement le tour actuel et les cercles indiquant la progression
3. **Intégration avec le système d'injection** - Amélioration de la manière dont les composants globaux sont référencés

### Modifications
- Mise à jour de `GameState.lua` pour restaurer l'appel à la pioche de cartes dans `nextTurn()`
- Restauration de l'interface visuelle des tours (cercles et indicateurs)
- Ajout de références globales sécurisées dans le conteneur de dépendances
- Amélioration du module de localisation avec plus de textes d'interface

### Approche
Cette correction utilise une double approche pour assurer la robustesse:
1. Elle essaie d'abord d'obtenir les références via le conteneur de dépendances (propre architecturalement)
2. Si cela échoue, elle utilise les références globales directement (méthode de secours)

Cette PR constitue une étape intermédiaire vers une architecture plus propre où toutes les dépendances seraient gérées via le conteneur d'injection, mais elle assure que le jeu fonctionne correctement dans l'état actuel.