### PR TITLE
Correction de l'affichage des cartes en main

### DIFF
--- a/src/systems/card_system.lua
+++ b/src/systems/card_system.lua
@@ -142,18 +142,20 @@ end
 
 -- Fonction pour dessiner la main du joueur en utilisant le renderer
 function CardSystem:drawHand()
-    local screenWidth = love.graphics.getWidth()
-    local screenHeight = love.graphics.getHeight()
+    local screenWidth, screenHeight
     local handY
-    
+
     -- Adapter les coordonnées en fonction de l'échelle
-    if self.scaleManager then
+    if self.scaleManager and self.scaleManager.initialized then
         -- Pour la version scalée, nous utilisons une position fixe qui sera
         -- adaptée automatiquement par le système de scaling
         screenWidth = self.scaleManager.referenceWidth
         screenHeight = self.scaleManager.referenceHeight
         handY = screenHeight - 100
     else
+        -- Obtenir les dimensions directement - de manière sécurisée
+        screenWidth = love.graphics.getWidth()
+        screenHeight = love.graphics.getHeight()
         handY = screenHeight - 100
     end
     


### PR DESCRIPTION
Cette PR corrige l'affichage des cartes dans la main du joueur qui n'apparaissaient plus après la correction du `ScaleManager`.

## Problème
Après la correction du `ScaleManager`, la main de cartes n'était plus visible en jeu en raison d'erreurs dans la méthode `drawHand()` du système de cartes.

## Solution
J'ai modifié la méthode `drawHand()` dans `card_system.lua` pour :
1. Vérifier que le gestionnaire d'échelle est bien initialisé avant de l'utiliser
2. Obtenir les dimensions de l'écran de manière plus sécurisée sans compter sur un format particulier des valeurs retournées par `love.graphics.getWidth()` et `love.graphics.getHeight()`

Cette correction s'ajoute à celle de la PR #20 concernant le `ScaleManager` pour assurer une exécution correcte du jeu.