### PR TITLE
Correction de la touche Échap pour quitter le plein écran

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -190,8 +190,12 @@ end
 function love.keypressed(key)
     if key == "f11" then
         love.window.setFullscreen(not love.window.getFullscreen(), "desktop")
-    elseif key == "escape" and love.window.getFullscreen() then
-        love.window.setFullscreen(false)
+    elseif key == "escape" then
+        -- Toujours quitter le mode plein écran avec Échap, que le mode soit actif ou non
+        if love.window.getFullscreen() then
+            love.window.setFullscreen(false)
+            print("Mode plein écran désactivé")
+        end
     end
 end
 


### PR DESCRIPTION
Cette PR corrige la gestion de la touche Échap pour quitter facilement le mode plein écran.

## Problème
Actuellement, la touche Échap ne permet pas de sortir du mode plein écran, ce qui peut piéger l'utilisateur dans ce mode s'il ne connaît pas le raccourci F11.

## Solution
Modification de la condition dans la fonction `love.keypressed()` pour que la touche Échap quitte **toujours** le mode plein écran s'il est actif, sans conditions supplémentaires.

Extrait du changement :
```lua
elseif key == "escape" then
    -- Toujours quitter le mode plein écran avec Échap, que le mode soit actif ou non
    if love.window.getFullscreen() then
        love.window.setFullscreen(false)
        print("Mode plein écran désactivé")
    end
```

Cette correction assure que l'utilisateur peut toujours sortir du mode plein écran en appuyant sur Échap.