### PR TITLE
Correction de la position des cartes en main

### DIFF
--- a/src/systems/card_system.lua
+++ b/src/systems/card_system.lua
@@ -9,6 +9,8 @@ CardSystem.__index = CardSystem
 -- Définition des constantes pour la taille des cartes
 local CARD_WIDTH = 108
 local CARD_HEIGHT = 180
+-- Position verticale fixe pour les cartes (pourcentage de la hauteur de l'écran)
+local HAND_POSITION_PERCENT = 0.75
 
 -- Le constructeur prend désormais des dépendances optionnelles
 function CardSystem.new(dependencies)
@@ -151,13 +153,14 @@ function CardSystem:drawHand()
         -- adaptée automatiquement par le système de scaling
         screenWidth = self.scaleManager.referenceWidth
         screenHeight = self.scaleManager.referenceHeight
-        handY = screenHeight - 100
     else
         -- Obtenir les dimensions directement
         screenWidth = love.graphics.getWidth()
         screenHeight = love.graphics.getHeight()
-        handY = screenHeight - 100
     end
+    
+    -- Calculer la position verticale en fonction de la hauteur d'écran (pourcentage fixe)
+    handY = screenHeight * HAND_POSITION_PERCENT
     
     -- Récupérer le renderer de cartes via l'injecteur de dépendances
     local cardRenderer = DependencyContainer.resolve("CardRenderer")


### PR DESCRIPTION
Cette PR ajuste la position des cartes en main pour garantir leur visibilité quelle que soit la résolution ou les proportions de l'écran.

## Problème
Les cartes sont positionnées trop bas dans l'interface et peuvent sortir de l'écran sur certaines résolutions ou proportions d'écran.

## Solution
1. Introduction d'une constante `HAND_POSITION_PERCENT` qui définit la position verticale des cartes en pourcentage de la hauteur de l'écran (75%)
2. Calcul dynamique de la position Y des cartes basé sur ce pourcentage
3. Séparation du calcul de dimensions d'écran et de la position pour plus de clarté

Cette approche garantit que les cartes restent visibles dans la partie inférieure de l'écran, mais suffisamment hautes pour être entièrement visibles, quelle que soit la résolution.