### PR TITLE
Réduction de 40% de la taille des éléments UI

### DIFF
--- a/src/states/game_state.lua
+++ b/src/states/game_state.lua
@@ -8,6 +8,22 @@ local Localization = require('src.utils.localization')
 local GameState = {}
 GameState.__index = GameState
 
+-- Dimensions et espacements réduits de 40%
+local UI_MARGIN = 6        -- 10 * 0.6
+local UI_PADDING = 12      -- 20 * 0.6
+local HEADER_HEIGHT = 24   -- 40 * 0.6
+local TURN_INDICATOR_HEIGHT = 18 -- 30 * 0.6
+local WEATHER_SECTION_HEIGHT = 30 -- 50 * 0.6
+local DIE_SIZE = 24        -- 40 * 0.6
+local DIE_CORNER_RADIUS = 4 -- 6 * 0.6
+local BUTTON_WIDTH = 48    -- 80 * 0.6
+local BUTTON_HEIGHT = 18   -- 30 * 0.6
+local TEXT_SCALE = 0.6     -- Échelle de texte réduite
+
+-- Position du plateau (réduite de 40%)
+local GARDEN_TOP_MARGIN = 96 -- 160 * 0.6
+local CELL_SIZE = 42       -- 70 * 0.6
+
 -- Constructeur modifié pour accepter les dépendances
 function GameState.new(dependencies)
     local self = setmetatable({}, GameState)
@@ -46,64 +62,84 @@ function GameState:draw()
     
     -- Interface utilisateur - haut de l'écran
     love.graphics.setColor(0.9, 0.95, 0.9)
-    love.graphics.rectangle("fill", 10, 10, 580, 40)
+    love.graphics.rectangle("fill", UI_MARGIN, UI_MARGIN, 580 * 0.6, HEADER_HEIGHT)
     love.graphics.setColor(0, 0, 0)
-    love.graphics.print(Localization.getText("ui.saison") .. ": " .. seasonText .. " (" .. math.ceil(self.currentTurn/2) .. "/4)", 30, 25)
+    love.graphics.print(Localization.getText("ui.saison") .. ": " .. seasonText .. " (" .. math.ceil(self.currentTurn/2) .. "/4)", UI_MARGIN + UI_PADDING, UI_MARGIN + 9, 0, TEXT_SCALE, TEXT_SCALE)
     
     -- Indicateur de tour
     love.graphics.setColor(0.8, 0.9, 0.95)
-    love.graphics.rectangle("fill", 10, 60, 580, 30)
+    love.graphics.rectangle("fill", UI_MARGIN, UI_MARGIN + HEADER_HEIGHT + 6, 580 * 0.6, TURN_INDICATOR_HEIGHT)
     love.graphics.setColor(0.4, 0.4, 0.4)
-    love.graphics.line(50, 75, 550, 75)
+    love.graphics.line(30, UI_MARGIN + HEADER_HEIGHT + 6 + TURN_INDICATOR_HEIGHT/2, 
+                       UI_MARGIN + 580 * 0.6 - 30, UI_MARGIN + HEADER_HEIGHT + 6 + TURN_INDICATOR_HEIGHT/2)
     
     -- Cercles des tours
+    local circleSpacing = (580 * 0.6 - 60) / 7
     for i = 1, 8 do
-        local x = 50 + (i-1) * 500/7
+        local x = 30 + (i-1) * circleSpacing
         if i == self.currentTurn then
             love.graphics.setColor(0.4, 0.4, 0.4)
-            love.graphics.circle("fill", x, 75, 8)
+            love.graphics.circle("fill", x, UI_MARGIN + HEADER_HEIGHT + 6 + TURN_INDICATOR_HEIGHT/2, 5)
         else
             love.graphics.setColor(0.4, 0.4, 0.4)
-            love.graphics.circle("line", x, 75, 8)
+            love.graphics.circle("line", x, UI_MARGIN + HEADER_HEIGHT + 6 + TURN_INDICATOR_HEIGHT/2, 5)
         end
     end
     
     -- Dés et bouton
+    local weatherTop = UI_MARGIN + HEADER_HEIGHT + 6 + TURN_INDICATOR_HEIGHT + 6
     love.graphics.setColor(0.8, 0.9, 0.95)
-    love.graphics.rectangle("fill", 10, 100, 580, 50)
+    love.graphics.rectangle("fill", UI_MARGIN, weatherTop, 580 * 0.6, WEATHER_SECTION_HEIGHT)
     
     -- Dé soleil
+    local dieX1 = UI_MARGIN + (580 * 0.6) * 0.4
     love.graphics.setColor(1, 0.8, 0)
-    love.graphics.rectangle("fill", 240, 105, 40, 40, 6)
+    love.graphics.rectangle("fill", dieX1, weatherTop + 3, DIE_SIZE, DIE_SIZE, DIE_CORNER_RADIUS)
     love.graphics.setColor(0, 0, 0)
-    love.graphics.print(self.sunDieValue, 255, 115)
-    love.graphics.print(Localization.getText("ui.soleil"), 245, 130)
+    love.graphics.print(self.sunDieValue, dieX1 + 9, weatherTop + 6, 0, TEXT_SCALE, TEXT_SCALE)
+    love.graphics.print(Localization.getText("ui.soleil"), dieX1 + 3, weatherTop + 18, 0, TEXT_SCALE, TEXT_SCALE)
     
     -- Dé pluie
+    local dieX2 = UI_MARGIN + (580 * 0.6) * 0.55
     love.graphics.setColor(0.6, 0.8, 1)
-    love.graphics.rectangle("fill", 310, 105, 40, 40, 6)
+    love.graphics.rectangle("fill", dieX2, weatherTop + 3, DIE_SIZE, DIE_SIZE, DIE_CORNER_RADIUS)
     love.graphics.setColor(0, 0, 0)
-    love.graphics.print(self.rainDieValue, 325, 115)
-    love.graphics.print(Localization.getText("ui.pluie"), 317, 130)
+    love.graphics.print(self.rainDieValue, dieX2 + 9, weatherTop + 6, 0, TEXT_SCALE, TEXT_SCALE)
+    love.graphics.print(Localization.getText("ui.pluie"), dieX2 + 6, weatherTop + 18, 0, TEXT_SCALE, TEXT_SCALE)
     
     -- Bouton fin de tour
+    local buttonX = UI_MARGIN + (580 * 0.6) * 0.8
     love.graphics.setColor(0.6, 0.8, 0.6)
-    love.graphics.rectangle("fill", 480, 110, 80, 30, 5)
+    love.graphics.rectangle("fill", buttonX, weatherTop + 6, BUTTON_WIDTH, BUTTON_HEIGHT, 3)
     love.graphics.setColor(0, 0, 0)
-    love.graphics.print(Localization.getText("ui.fin_tour"), 487, 120)
+    love.graphics.print(Localization.getText("ui.fin_tour"), buttonX + 3, weatherTop + 12, 0, TEXT_SCALE, TEXT_SCALE)
     
     -- Score
     love.graphics.setColor(0, 0, 0)
-    love.graphics.print(Localization.getText("ui.score") .. ": " .. self.score .. "/" .. self.objective, 10, 160)
+    love.graphics.print(Localization.getText("ui.score") .. ": " .. self.score .. "/" .. self.objective, UI_MARGIN, weatherTop + WEATHER_SECTION_HEIGHT + 6, 0, TEXT_SCALE, TEXT_SCALE)
     
     -- Dessin du jardin avec son renderer dédié
-    gardenRenderer:draw(self.garden)
+    -- Transmission de la position du jardin et de la taille des cellules
+    gardenRenderer:draw(self.garden, UI_MARGIN, GARDEN_TOP_MARGIN, CELL_SIZE)
 end
 
 function GameState:mousepressed(x, y, button)
     -- Vérifier si le bouton fin de tour a été cliqué
-    if button == 1 and x >= 480 and x <= 560 and y >= 110 and y <= 140 then
+    local weatherTop = UI_MARGIN + HEADER_HEIGHT + 6 + TURN_INDICATOR_HEIGHT + 6
+    local buttonX = UI_MARGIN + (580 * 0.6) * 0.8
+    
+    if button == 1 and x >= buttonX and x <= buttonX + BUTTON_WIDTH and 
+                       y >= weatherTop + 6 and y <= weatherTop + 6 + BUTTON_HEIGHT then
         self:nextTurn()
+    end
+    
+    -- Vérifier si une cellule du jardin a été cliquée
+    local cellX = math.floor((x - UI_MARGIN) / CELL_SIZE) + 1
+    local cellY = math.floor((y - GARDEN_TOP_MARGIN) / CELL_SIZE) + 1
+    
+    if cellX >= 1 and cellX <= self.garden.width and 
+       cellY >= 1 and cellY <= self.garden.height then
+        -- Traitement du clic sur une cellule (à implémenter)
     end
 end
 

--- a/src/systems/card_system.lua
+++ b/src/systems/card_system.lua
@@ -6,11 +6,15 @@ local DependencyContainer = require('src.utils.dependency_container')
 local CardSystem = {}
 CardSystem.__index = CardSystem
 
--- Définition des constantes pour la taille des cartes
-local CARD_WIDTH = 108
-local CARD_HEIGHT = 180
+-- Définition des constantes pour la taille des cartes (réduites de 40%)
+local CARD_WIDTH = 65  -- 108 * 0.6
+local CARD_HEIGHT = 108 -- 180 * 0.6
+
 -- Position verticale fixe pour les cartes (pourcentage de la hauteur de l'écran)
 local HAND_POSITION_PERCENT = 0.75
+-- Espacement entre les cartes réduit de 40%
+local CARD_SPACING_X = 162 -- 270 * 0.6
+local CARD_ARC_HEIGHT = 42 -- 70 * 0.6
 
 -- Le constructeur prend désormais des dépendances optionnelles
 function CardSystem.new(dependencies)
@@ -170,8 +174,8 @@ function CardSystem:drawHand()
         -- Ignorer la carte en cours de déplacement ou d'animation
         if i ~= self.draggingCardIndex and i ~= self.cardInAnimation then
             local angle = (i - (#self.hand + 1) / 2) * 0.1
-            local x = screenWidth / 2 + angle * 270
-            local y = handY + math.abs(angle) * 70
+            local x = screenWidth / 2 + angle * CARD_SPACING_X
+            local y = handY + math.abs(angle) * CARD_ARC_HEIGHT
             
             -- Stocker la position pour le drag & drop
             card.x = x

--- a/src/ui/card_renderer.lua
+++ b/src/ui/card_renderer.lua
@@ -5,12 +5,13 @@ local Localization = require('src.utils.localization')
 local CardRenderer = {}
 CardRenderer.__index = CardRenderer
 
--- Définition des constantes pour la taille des cartes (180% de la taille originale)
-local CARD_WIDTH = 108  -- 60 * 1.8
-local CARD_HEIGHT = 180 -- 100 * 1.8
-local CARD_CORNER_RADIUS = 5
-local CARD_HEADER_HEIGHT = 27 -- 15 * 1.8
-local TEXT_SCALE = 1.4
+-- Réduction de 40% des dimensions originales
+-- Définition des constantes pour la taille des cartes (108%)
+local CARD_WIDTH = 65  -- 108 * 0.6 (réduit de 40%)
+local CARD_HEIGHT = 108 -- 180 * 0.6 (réduit de 40%)
+local CARD_CORNER_RADIUS = 3 -- 5 * 0.6
+local CARD_HEADER_HEIGHT = 16 -- 27 * 0.6
+local TEXT_SCALE = 0.84 -- 1.4 * 0.6
 
 function CardRenderer.new()
     local self = setmetatable({}, CardRenderer)
@@ -43,7 +44,7 @@ function CardRenderer:draw(card, xPos, yPos)
     else
         love.graphics.setColor(0.7, 0.7, 0.7, 1)
     end
-    love.graphics.rectangle("fill", cardLeft + 5, cardTop + 5, CARD_WIDTH - 10, CARD_HEADER_HEIGHT)
+    love.graphics.rectangle("fill", cardLeft + 3, cardTop + 3, CARD_WIDTH - 6, CARD_HEADER_HEIGHT)
     
     -- Obtenir le texte localisé pour la famille
     local familyText
@@ -55,28 +56,28 @@ function CardRenderer:draw(card, xPos, yPos)
     
     -- Nom et info
     love.graphics.setColor(0, 0, 0, 1)
-    love.graphics.print(familyText, cardLeft + 10, cardTop + 9, 0, TEXT_SCALE, TEXT_SCALE)
+    love.graphics.print(familyText, cardLeft + 6, cardTop + 5, 0, TEXT_SCALE, TEXT_SCALE)
     
     -- Info sur le stade
     local stageText = "Graine" -- Par défaut
     if Localization and Localization.getText and Constants and Constants.GROWTH_STAGE and Constants.GROWTH_STAGE.SEED then
         stageText = Localization.getText(Constants.GROWTH_STAGE.SEED) or "Graine"
     end
-    love.graphics.print(stageText, cardLeft + 10, cardTop + 35, 0, TEXT_SCALE, TEXT_SCALE)
+    love.graphics.print(stageText, cardLeft + 6, cardTop + 21, 0, TEXT_SCALE, TEXT_SCALE)
     
     -- Besoins pour pousser
-    love.graphics.print("☀️ " .. card.sunToSprout, cardLeft + 10, cardTop + 60, 0, TEXT_SCALE, TEXT_SCALE)
-    love.graphics.print("🌧️ " .. card.rainToSprout, cardLeft + 10, cardTop + 85, 0, TEXT_SCALE, TEXT_SCALE)
+    love.graphics.print("☀️ " .. card.sunToSprout, cardLeft + 6, cardTop + 36, 0, TEXT_SCALE, TEXT_SCALE)
+    love.graphics.print("🌧️ " .. card.rainToSprout, cardLeft + 6, cardTop + 51, 0, TEXT_SCALE, TEXT_SCALE)
     
     -- Score
     local pointsText = "pts"
     if Localization and Localization.getText then
         pointsText = Localization.getText("ui.points") or "pts"
     end
-    love.graphics.print(card.baseScore .. " " .. pointsText, cardLeft + 10, cardTop + 110, 0, TEXT_SCALE, TEXT_SCALE)
+    love.graphics.print(card.baseScore .. " " .. pointsText, cardLeft + 6, cardTop + 66, 0, TEXT_SCALE, TEXT_SCALE)
     
     -- Gel
-    love.graphics.print("❄️ " .. card.frostThreshold, cardLeft + 10, cardTop + 135, 0, TEXT_SCALE, TEXT_SCALE)
+    love.graphics.print("❄️ " .. card.frostThreshold, cardLeft + 6, cardTop + 81, 0, TEXT_SCALE, TEXT_SCALE)
     
     -- Restaurer l'état graphique
     love.graphics.pop()

--- a/src/ui/drag_drop.lua
+++ b/src/ui/drag_drop.lua
@@ -4,13 +4,13 @@ local DependencyContainer = require('src.utils.dependency_container')
 local DragDrop = {}
 DragDrop.__index = DragDrop
 
--- Définition des constantes pour la taille des cartes
-local CARD_WIDTH = 108  -- Taille de base des cartes (60 * 1.8)
-local CARD_HEIGHT = 180 -- (100 * 1.8)
-local CARD_CORNER_RADIUS = 5
-local CARD_HEADER_HEIGHT = 27 -- (15 * 1.8)
-local TEXT_PADDING_X = 45
-local TEXT_LINE_HEIGHT = 18
+-- Définition des constantes pour la taille des cartes (réduites de 40%)
+local CARD_WIDTH = 65  -- 108 * 0.6
+local CARD_HEIGHT = 108 -- 180 * 0.6
+local CARD_CORNER_RADIUS = 3 -- 5 * 0.6
+local CARD_HEADER_HEIGHT = 16 -- 27 * 0.6
+local TEXT_PADDING_X = 27 -- 45 * 0.6
+local TEXT_LINE_HEIGHT = 11 -- 18 * 0.6
 
 -- Constantes d'animation
 local ANIMATION_DURATION = 0.3 -- Durée de l'animation en secondes
@@ -154,18 +154,23 @@ function DragDrop:stopDrag(garden)
     
     local placed = false
     
+    -- Taille d'une cellule réduite de 40%
+    local cellSize = 42 -- 70 * 0.6
+    local gardenX = 6   -- UI_MARGIN
+    local gardenY = 96  -- GARDEN_TOP_MARGIN
+    
     -- Trouver la cellule sous la carte
     for y = 1, garden.height do
         for x = 1, garden.width do
-            local posX = 50 + (x-1) * 70
-            local posY = 180 + (y-1) * 70
+            local posX = gardenX + (x-1) * cellSize
+            local posY = gardenY + (y-1) * cellSize
             
             -- Utiliser le centre de la carte pour la détection
             local cardCenterX = self.dragging.x
             local cardCenterY = self.dragging.y
             
-            if cardCenterX >= posX and cardCenterX < posX + 70 and
-               cardCenterY >= posY and cardCenterY < posY + 70 then
+            if cardCenterX >= posX and cardCenterX < posX + cellSize and
+               cardCenterY >= posY and cardCenterY < posY + cellSize then
                 
                 -- Tenter de placer la plante
                 if not garden.grid[y][x].plant then
@@ -216,14 +221,19 @@ function DragDrop:updateHighlight(garden, x, y)
     -- Ne pas afficher de surbrillance si une animation est en cours
     if self.moveAnimation.active or not self.dragging then return end
     
+    -- Taille d'une cellule réduite de 40%
+    local cellSize = 42 -- 70 * 0.6
+    local gardenX = 6   -- UI_MARGIN
+    local gardenY = 96  -- GARDEN_TOP_MARGIN
+    
     -- Réinitialiser les surbrillances
     for cy = 1, garden.height do
         for cx = 1, garden.width do
             local cell = {
-                x = 50 + (cx-1) * 70,
-                y = 180 + (cy-1) * 70,
-                width = 70,
-                height = 70
+                x = gardenX + (cx-1) * cellSize,
+                y = gardenY + (cy-1) * cellSize,
+                width = cellSize,
+                height = cellSize
             }
             
             local highlight = x >= cell.x and x < cell.x + cell.width and
@@ -234,7 +244,7 @@ function DragDrop:updateHighlight(garden, x, y)
                 love.graphics.setColor(0.8, 0.9, 0.7, 0.6)
                 love.graphics.rectangle("fill", cell.x, cell.y, cell.width, cell.height)
                 love.graphics.setColor(0.4, 0.8, 0.4)
-                love.graphics.rectangle("line", cell.x, cell.y, cell.width, cell.height, 3)
+                love.graphics.rectangle("line", cell.x, cell.y, cell.width, cell.height, 2)
             end
         end
     end
@@ -264,8 +274,8 @@ function DragDrop:draw()
         -- Dessiner une ombre
         love.graphics.setColor(0, 0, 0, 0.2)
         love.graphics.rectangle("fill", 
-            cardLeft + 4 * scale, 
-            cardTop + 4 * scale, 
+            cardLeft + 2 * scale, 
+            cardTop + 2 * scale, 
             scaledWidth, scaledHeight, CARD_CORNER_RADIUS)
         
         -- Dessiner la carte elle-même
@@ -280,26 +290,26 @@ function DragDrop:draw()
         else
             love.graphics.setColor(0.7, 0.7, 0.7)
         end
-        love.graphics.rectangle("fill", cardLeft + 5 * scale, cardTop + 5 * scale, 
-                               scaledWidth - 10 * scale, scaledHeaderHeight)
+        love.graphics.rectangle("fill", cardLeft + 3 * scale, cardTop + 3 * scale, 
+                               scaledWidth - 6 * scale, scaledHeaderHeight)
         
         -- Calculer l'échelle du texte pour les cartes redimensionnées
-        local textScale = 1.4 * scale
+        local textScale = 0.84 * scale
         
         -- Nom et info
         love.graphics.setColor(0, 0, 0)
-        love.graphics.print(card.family, cardLeft + 10 * scale, cardTop + 9 * scale, 0, textScale, textScale)
-        love.graphics.print("Graine", cardLeft + 10 * scale, cardTop + 35 * scale, 0, textScale, textScale)
+        love.graphics.print(card.family, cardLeft + 6 * scale, cardTop + 5 * scale, 0, textScale, textScale)
+        love.graphics.print("Graine", cardLeft + 6 * scale, cardTop + 21 * scale, 0, textScale, textScale)
         
         -- Besoins pour pousser
-        love.graphics.print("☀️ " .. card.sunToSprout, cardLeft + 10 * scale, cardTop + 60 * scale, 0, textScale, textScale)
-        love.graphics.print("🌧️ " .. card.rainToSprout, cardLeft + 10 * scale, cardTop + 85 * scale, 0, textScale, textScale)
+        love.graphics.print("☀️ " .. card.sunToSprout, cardLeft + 6 * scale, cardTop + 36 * scale, 0, textScale, textScale)
+        love.graphics.print("🌧️ " .. card.rainToSprout, cardLeft + 6 * scale, cardTop + 51 * scale, 0, textScale, textScale)
         
         -- Score
-        love.graphics.print(card.baseScore .. " pts", cardLeft + 10 * scale, cardTop + 110 * scale, 0, textScale, textScale)
+        love.graphics.print(card.baseScore .. " pts", cardLeft + 6 * scale, cardTop + 66 * scale, 0, textScale, textScale)
         
         -- Gel
-        love.graphics.print("❄️ " .. card.frostThreshold, cardLeft + 10 * scale, cardTop + 135 * scale, 0, textScale, textScale)
+        love.graphics.print("❄️ " .. card.frostThreshold, cardLeft + 6 * scale, cardTop + 81 * scale, 0, textScale, textScale)
     end
 end
 

--- a/src/ui/garden_renderer.lua
+++ b/src/ui/garden_renderer.lua
@@ -1,39 +1,99 @@
 -- Renderer dédié pour le jardin
+local Constants = require('src.utils.constants')
 local DependencyContainer = require('src.utils.dependency_container')
 
 local GardenRenderer = {}
 GardenRenderer.__index = GardenRenderer
+
+-- Constantes de rendu (réduites de 40%)
+local CELL_DEFAULT_SIZE = 42  -- 70 * 0.6
+local CELL_PADDING = 3        -- 5 * 0.6
+local TEXT_SCALE = 0.6        -- Échelle de texte réduite
 
 function GardenRenderer.new()
     local self = setmetatable({}, GardenRenderer)
     return self
 end
 
--- Méthode pour dessiner le jardin complet
-function GardenRenderer:draw(garden)
-    local cellWidth = 70
-    local cellHeight = 70
-    local offsetX = 50
-    local offsetY = 180  -- Aligné avec le système de drag & drop
+-- Méthode pour dessiner le jardin avec les plantes
+function GardenRenderer:draw(garden, x, y, cellSize)
+    -- Utiliser la taille fournie ou la taille par défaut
+    local size = cellSize or CELL_DEFAULT_SIZE
     
-    -- Obtenir le renderer de plantes via le conteneur de dépendances
-    local plantRenderer = DependencyContainer.resolve("PlantRenderer")
+    -- Dessiner le fond du jardin
+    love.graphics.setColor(0.9, 0.8, 0.6) -- Couleur terre/sable
+    love.graphics.rectangle("fill", x, y, garden.width * size, garden.height * size)
     
     -- Dessiner les cellules du jardin
-    for y = 1, garden.height do
-        for x = 1, garden.width do
-            local posX = offsetX + (x-1) * cellWidth
-            local posY = offsetY + (y-1) * cellHeight
+    for cy = 1, garden.height do
+        for cx = 1, garden.width do
+            local cellX = x + (cx - 1) * size
+            local cellY = y + (cy - 1) * size
             
-            -- Dessiner la case
-            love.graphics.setColor(0.8, 0.7, 0.5)
-            love.graphics.rectangle("fill", posX, posY, cellWidth, cellHeight)
-            love.graphics.setColor(0.4, 0.4, 0.4)
-            love.graphics.rectangle("line", posX, posY, cellWidth, cellHeight)
+            -- Couleur de fond de la cellule selon son état
+            local cell = garden.grid[cy][cx]
             
-            -- Dessiner plante si présente, en utilisant le renderer dédié
-            if garden.grid[y][x].plant then
-                plantRenderer:draw(garden.grid[y][x].plant, posX, posY, cellWidth, cellHeight)
+            -- Dessiner le contour de la cellule
+            love.graphics.setColor(0.7, 0.6, 0.4) -- Brun foncé pour les bordures
+            love.graphics.rectangle("line", cellX, cellY, size, size)
+            
+            -- Dessiner le contenu de la cellule
+            if cell.plant then
+                -- Dessiner la plante en utilisant sa couleur
+                love.graphics.setColor(cell.plant.color[1], cell.plant.color[2], cell.plant.color[3])
+                
+                -- Dessiner en fonction du stade de croissance
+                if cell.plant.growthStage == Constants.GROWTH_STAGE.SEED then
+                    -- Graine: petit cercle
+                    love.graphics.circle("fill", cellX + size/2, cellY + size/2, size/6)
+                    love.graphics.setColor(0, 0, 0)
+                    love.graphics.circle("line", cellX + size/2, cellY + size/2, size/6)
+                elseif cell.plant.growthStage == Constants.GROWTH_STAGE.SPROUT then
+                    -- Pousse: rectangle arrondi moyen
+                    love.graphics.rectangle("fill", cellX + size/4, cellY + size/4, size/2, size/2, 3, 3)
+                    love.graphics.setColor(0, 0, 0)
+                    love.graphics.rectangle("line", cellX + size/4, cellY + size/4, size/2, size/2, 3, 3)
+                elseif cell.plant.growthStage == Constants.GROWTH_STAGE.FRUIT then
+                    -- Fructifié: rectangle arrondi presque plein
+                    love.graphics.rectangle("fill", cellX + CELL_PADDING, cellY + CELL_PADDING, 
+                                          size - 2*CELL_PADDING, size - 2*CELL_PADDING, 3, 3)
+                    love.graphics.setColor(0, 0, 0)
+                    love.graphics.rectangle("line", cellX + CELL_PADDING, cellY + CELL_PADDING, 
+                                          size - 2*CELL_PADDING, size - 2*CELL_PADDING, 3, 3)
+                end
+                
+                -- Afficher les infos de la plante
+                love.graphics.setColor(0, 0, 0)
+                
+                -- Afficher la famille au-dessus
+                local familyText = cell.plant.family:sub(1, 3) -- Abréviation
+                love.graphics.print(familyText, cellX + 3, cellY + 3, 0, TEXT_SCALE, TEXT_SCALE)
+                
+                -- Afficher le stade en bas
+                local stageText = "Graine"
+                if cell.plant.growthStage == Constants.GROWTH_STAGE.SPROUT then
+                    stageText = "Plant"
+                elseif cell.plant.growthStage == Constants.GROWTH_STAGE.FRUIT then
+                    stageText = "Mûr"
+                end
+                love.graphics.print(stageText, cellX + 3, cellY + size - 12, 0, TEXT_SCALE, TEXT_SCALE)
+                
+                -- Afficher les compteurs de soleil et pluie
+                local sunText = "☀️" .. cell.plant.accumulatedSun .. "/" .. cell.plant.sunToFruit
+                local rainText = "🌧️" .. cell.plant.accumulatedRain .. "/" .. cell.plant.rainToFruit
+                
+                if cell.plant.growthStage == Constants.GROWTH_STAGE.SEED then
+                    sunText = "☀️" .. cell.plant.accumulatedSun .. "/" .. cell.plant.sunToSprout
+                    rainText = "🌧️" .. cell.plant.accumulatedRain .. "/" .. cell.plant.rainToSprout
+                end
+                
+                love.graphics.print(sunText, cellX + 3, cellY + size - 24, 0, TEXT_SCALE, TEXT_SCALE)
+                love.graphics.print(rainText, cellX + 3, cellY + size - 36, 0, TEXT_SCALE, TEXT_SCALE)
+            end
+            
+            -- Dessiner un objet s'il existe
+            if cell.object then
+                -- TODO: implémenter dessin des objets
             end
         end
     end


### PR DESCRIPTION
Cette PR réduit de 40% la taille de tous les éléments de l'interface utilisateur pour une meilleure lisibilité et efficacité d'affichage.

## Modifications
Les dimensions et espacements ont été réduits de 40% dans tous les composants UI :

1. **CardRenderer**
   - Taille des cartes : 108×180px → 65×108px
   - Échelle de texte : 1.4 → 0.84
   - Rayons des coins et marges internes ajustés

2. **CardSystem**
   - Dimensions des cartes
   - Espacement entre cartes : 270px → 162px
   - Hauteur de l'arc des cartes : 70px → 42px

3. **GameState**
   - Tous les éléments UI (marges, hauteurs, boutons, espacement, etc.)
   - Taille et position du jardin
   - Taille des dés et des indicateurs

4. **GardenRenderer**
   - Taille des cellules : 70px → 42px
   - Échelle de texte et indicateurs visuels des plantes

5. **DragDrop**
   - Adaptation des valeurs de détection et d'interaction
   - Animation et déplacement ajustés

Cette réduction de 40% appliquée uniformément permet de conserver les proportions tout en rendant l'interface plus compacte et adaptable aux différentes résolutions d'écran.