### PR TITLE
Suppression de la sidebar et utilisation du composant main pleine largeur

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 Ce document liste les modifications majeures apportées au projet depuis sa création.
 
+## [Non publié] - 2025-03-18
+
+### Amélioration
+- **Interface utilisateur**
+  - Suppression de la sidebar et extension du composant main à toute la largeur de la fenêtre
+  - Repositionnement des éléments d'interface pour exploiter tout l'espace disponible
+  - Agrandissement de la zone de potager pour faciliter les interactions
+  - Meilleure utilisation de l'espace d'écran horizontal
+
 ## [Non publié] - 2025-03-15
 
 ### Corrections

--- a/src/ui/layout_manager.lua
+++ b/src/ui/layout_manager.lua
@@ -10,22 +10,15 @@ function LayoutManager.new(params)
     
     -- Conteneurs principaux
     self.containers = {
-        -- Zone principale (gauche) - 75% de la largeur
+        -- Un seul conteneur main qui occupe toute la fenêtre
         main = {
             relX = 0,
             relY = 0,
-            relWidth = 0.75,
-            relHeight = 1,
-            components = {}
-        },
-        -- Colonne d'information (droite) - 25% de la largeur
-        sidebar = {
-            relX = 0.75,
-            relY = 0,
-            relWidth = 0.25,
+            relWidth = 1,     -- 100% de la largeur au lieu de 75%
             relHeight = 1,
             components = {}
         }
+        -- La sidebar a été supprimée
     }
     
     -- Positions et dimensions absolues calculées

--- a/src/ui/ui_manager.lua
+++ b/src/ui/ui_manager.lua
@@ -36,11 +36,22 @@ function UIManager.new(params)
 end
 
 function UIManager:createComponents()
-    -- Bannière de saison (en haut de l'écran principal)
+    -- Panneau de score (repositionné en haut à droite)
+    local scorePanel = ScorePanel.new({
+        relX = 0.75,       -- Déplacé en haut à droite
+        relY = 0,
+        relWidth = 0.25,   -- Conserve la même largeur
+        relHeight = 0.15,  -- Légèrement réduit en hauteur
+        gameState = self.gameState,
+        scaleManager = self.scaleManager
+    })
+    self.layoutManager:addComponent("main", scorePanel)
+    
+    -- Bannière de saison (en haut à gauche)
     local seasonBanner = SeasonBanner.new({
         relX = 0,
         relY = 0,
-        relWidth = 1,
+        relWidth = 0.75,   -- Redimensionné pour laisser de la place au score panel
         relHeight = 0.07,
         gameState = self.gameState,
         scaleManager = self.scaleManager
@@ -59,12 +70,12 @@ function UIManager:createComponents()
     })
     self.layoutManager:addComponent("main", weatherDice)
     
-    -- Affichage du potager
+    -- Affichage du potager (légèrement plus grand)
     local gardenDisplay = GardenDisplay.new({
-        relX = 0,
+        relX = 0.05,      -- Centré horizontalement
         relY = 0.2,
-        relWidth = 1,
-        relHeight = 0.5,
+        relWidth = 0.9,   -- Utilise plus d'espace horizontal
+        relHeight = 0.55, -- Légèrement plus grand pour profiter de l'espace
         garden = self.garden,
         gardenRenderer = self.gardenRenderer,
         dragDrop = self.dragDrop,
@@ -83,17 +94,6 @@ function UIManager:createComponents()
         scaleManager = self.scaleManager
     })
     self.layoutManager:addComponent("main", handDisplay)
-    
-    -- Panneau de score (partie supérieure de la colonne latérale)
-    local scorePanel = ScorePanel.new({
-        relX = 0,
-        relY = 0,
-        relWidth = 1,
-        relHeight = 0.2,
-        gameState = self.gameState,
-        scaleManager = self.scaleManager
-    })
-    self.layoutManager:addComponent("sidebar", scorePanel)
     
     -- Stocker des références aux composants principaux pour accès rapide
     self.components = {


### PR DESCRIPTION
## Description
Cette PR modifie l'interface de jeu pour supprimer complètement la sidebar et utiliser un conteneur main qui occupe toute la largeur de la fenêtre. Les composants qui étaient précédemment dans la sidebar ont été repositionnés dans la zone principale.

## Modifications
- Suppression de la sidebar dans le LayoutManager
- Extension du conteneur main à 100% de la largeur
- Repositionnement du panneau de score en haut à droite
- Élargissement de la zone de potager pour profiter de l'espace disponible
- Mise à jour du CHANGELOG pour documenter cette amélioration

## Bénéfices
- Plus d'espace pour les éléments de jeu, notamment le potager
- Interface plus épurée, moins compartimentée
- Meilleure utilisation de l'espace horizontal, particulièrement sur les écrans larges

## Captures d'écran
*(Des captures d'écran seraient normalement incluses ici pour illustrer les changements)*

## Tests effectués
- Vérification du positionnement des composants dans diverses tailles d'écran
- Test des interactions avec les composants après repositionnement