### PR TITLE
Définition des positions et dimensions en pixels avec référence HD

### DIFF
--- a/docs/ui-pixel-layout.md
+++ b/docs/ui-pixel-layout.md
@@ -1,0 +1,95 @@
+# Système de Layout Basé sur les Pixels pour Fructidor
+
+Ce document explique le système de positionnement et dimensionnement de l'interface utilisateur de Fructidor, basé sur une référence pixel HD.
+
+## Principes fondamentaux
+
+### Résolution de référence
+
+Toutes les positions et dimensions sont définies en pixels, en se basant sur une résolution de référence HD :
+
+- Largeur : 1920 pixels
+- Hauteur : 1080 pixels
+
+Cette référence permet d'avoir un point de départ cohérent pour le design de l'interface, tout en permettant l'adaptation à différentes résolutions d'écran.
+
+### Mise à l'échelle automatique
+
+Le `ScaleManager` s'occupe d'adapter automatiquement ces valeurs de référence à la résolution réelle de l'utilisateur :
+
+- Les positions sont multipliées par le facteur d'échelle calculé
+- Les dimensions sont multipliées par le même facteur
+- Un facteur d'échelle uniforme (min(scaleX, scaleY)) est utilisé pour conserver les proportions
+
+## Organisation du code
+
+### Fichier de constantes
+
+Toutes les valeurs de référence sont centralisées dans `src/ui/constants.lua` :
+
+```lua
+-- Exemples
+constants.REFERENCE_WIDTH = 1920
+constants.REFERENCE_HEIGHT = 1080
+constants.UI_MARGIN = 10
+constants.HEADER_HEIGHT = 40
+constants.CARD_WIDTH = 108
+```
+
+Ces constantes représentent les valeurs en pixels à résolution 1920x1080.
+
+### Utilisation dans les composants
+
+Les composants d'interface utilisent ces constantes en les combinant avec le facteur d'échelle :
+
+```lua
+-- Exemple de rendu avec mise à l'échelle
+love.graphics.rectangle("fill", 
+                       UIConstants.UI_MARGIN, 
+                       UIConstants.UI_MARGIN, 
+                       UIConstants.MAIN_PANEL_WIDTH * scale, 
+                       UIConstants.HEADER_HEIGHT)
+```
+
+## Fonctions utilitaires
+
+Le `ScaleManager` fournit des fonctions utilitaires pour convertir entre les valeurs en pixels de référence et les valeurs mises à l'échelle :
+
+- `ScaleManager.pixelToScale(pixelValue)` : Convertit une valeur en pixels de référence vers une valeur mise à l'échelle
+- `ScaleManager.scaleToPixel(scaledValue)` : Opération inverse, pour récupérer la valeur en pixels de référence
+
+## Bonnes pratiques
+
+1. **Toujours utiliser les constantes** : Ne pas coder en dur des valeurs en pixels dans les composants
+2. **Appliquer l'échelle** : Utiliser `ScaleManager.applyScale()` et `ScaleManager.restoreScale()` pour dessiner à l'échelle
+3. **Coordonnées de souris** : Ajuster les coordonnées de souris avec `mouseX / ScaleManager.scale` pour détecter correctement les interactions
+4. **Nouvelles valeurs** : Ajouter toute nouvelle constante d'interface dans `src/ui/constants.lua` pour maintenir la centralisation
+
+## Avantages
+
+- **Conception simplifiée** : Travail avec des valeurs de pixels réelles et intuitives
+- **Cohérence visuelle** : Maintien des proportions sur toutes les résolutions
+- **Maintenance facilitée** : Modification centralisée des dimensions et positions
+- **Adaptabilité** : Support naturel des écrans de différentes tailles
+
+## Exemple d'utilisation
+
+```lua
+local UIConstants = require('src.ui.constants')
+
+-- Dans une fonction de dessin
+function MyComponent:draw()
+    -- Appliquer l'échelle globale
+    ScaleManager.applyScale()
+    
+    -- Dessiner en utilisant les constantes
+    love.graphics.rectangle("fill", 
+                           UIConstants.UI_MARGIN, 
+                           UIConstants.UI_MARGIN, 
+                           UIConstants.CARD_WIDTH, 
+                           UIConstants.CARD_HEIGHT)
+    
+    -- Restaurer l'échelle
+    ScaleManager.restoreScale()
+end
+```

--- a/src/states/game_state.lua
+++ b/src/states/game_state.lua
@@ -4,25 +4,10 @@ local Constants = require('src.utils.constants')
 local Config = require('src.utils.config')
 local DependencyContainer = require('src.utils.dependency_container')
 local Localization = require('src.utils.localization')
+local UIConstants = require('src.ui.constants')
 
 local GameState = {}
 GameState.__index = GameState
-
--- Dimensions et espacements réduits de 40%
-local UI_MARGIN = 6        -- 10 * 0.6
-local UI_PADDING = 12      -- 20 * 0.6
-local HEADER_HEIGHT = 24   -- 40 * 0.6
-local TURN_INDICATOR_HEIGHT = 18 -- 30 * 0.6
-local WEATHER_SECTION_HEIGHT = 30 -- 50 * 0.6
-local DIE_SIZE = 24        -- 40 * 0.6
-local DIE_CORNER_RADIUS = 4 -- 6 * 0.6
-local BUTTON_WIDTH = 48    -- 80 * 0.6
-local BUTTON_HEIGHT = 18   -- 30 * 0.6
-local TEXT_SCALE = 0.6     -- Échelle de texte réduite
-
--- Position du plateau (réduite de 40%)
-local GARDEN_TOP_MARGIN = 96 -- 160 * 0.6
-local CELL_SIZE = 42       -- 70 * 0.6
 
 -- Constructeur modifié pour accepter les dépendances
 function GameState.new(dependencies)
@@ -60,82 +45,144 @@ function GameState:draw()
     -- Obtenir le texte de saison localisé
     local seasonText = Localization.getText(self.currentSeason)
     
+    -- Facteur d'échelle pour la réduction des éléments d'interface
+    local scale = UIConstants.CARD_SCALE_WHEN_DRAGGED -- Même échelle que pour drag & drop
+
     -- Interface utilisateur - haut de l'écran
     love.graphics.setColor(0.9, 0.95, 0.9)
-    love.graphics.rectangle("fill", UI_MARGIN, UI_MARGIN, 580 * 0.6, HEADER_HEIGHT)
+    love.graphics.rectangle("fill", 
+                           UIConstants.UI_MARGIN, 
+                           UIConstants.UI_MARGIN, 
+                           UIConstants.MAIN_PANEL_WIDTH * scale, 
+                           UIConstants.HEADER_HEIGHT)
     love.graphics.setColor(0, 0, 0)
-    love.graphics.print(Localization.getText("ui.saison") .. ": " .. seasonText .. " (" .. math.ceil(self.currentTurn/2) .. "/4)", UI_MARGIN + UI_PADDING, UI_MARGIN + 9, 0, TEXT_SCALE, TEXT_SCALE)
+    love.graphics.print(Localization.getText("ui.saison") .. ": " .. seasonText .. " (" .. math.ceil(self.currentTurn/2) .. "/4)", 
+                       UIConstants.UI_MARGIN + UIConstants.UI_PADDING, 
+                       UIConstants.UI_MARGIN + 9, 
+                       0, scale, scale)
     
     -- Indicateur de tour
     love.graphics.setColor(0.8, 0.9, 0.95)
-    love.graphics.rectangle("fill", UI_MARGIN, UI_MARGIN + HEADER_HEIGHT + 6, 580 * 0.6, TURN_INDICATOR_HEIGHT)
+    love.graphics.rectangle("fill", 
+                           UIConstants.UI_MARGIN, 
+                           UIConstants.UI_MARGIN + UIConstants.HEADER_HEIGHT + 6, 
+                           UIConstants.MAIN_PANEL_WIDTH * scale, 
+                           UIConstants.TURN_INDICATOR_HEIGHT)
     love.graphics.setColor(0.4, 0.4, 0.4)
-    love.graphics.line(30, UI_MARGIN + HEADER_HEIGHT + 6 + TURN_INDICATOR_HEIGHT/2, 
-                       UI_MARGIN + 580 * 0.6 - 30, UI_MARGIN + HEADER_HEIGHT + 6 + TURN_INDICATOR_HEIGHT/2)
+    love.graphics.line(30, UIConstants.UI_MARGIN + UIConstants.HEADER_HEIGHT + 6 + UIConstants.TURN_INDICATOR_HEIGHT/2, 
+                       UIConstants.UI_MARGIN + UIConstants.MAIN_PANEL_WIDTH * scale - 30, 
+                       UIConstants.UI_MARGIN + UIConstants.HEADER_HEIGHT + 6 + UIConstants.TURN_INDICATOR_HEIGHT/2)
     
     -- Cercles des tours
-    local circleSpacing = (580 * 0.6 - 60) / 7
+    local circleSpacing = (UIConstants.MAIN_PANEL_WIDTH * scale - 60) / 7
     for i = 1, 8 do
         local x = 30 + (i-1) * circleSpacing
         if i == self.currentTurn then
             love.graphics.setColor(0.4, 0.4, 0.4)
-            love.graphics.circle("fill", x, UI_MARGIN + HEADER_HEIGHT + 6 + TURN_INDICATOR_HEIGHT/2, 5)
+            love.graphics.circle("fill", x, UIConstants.UI_MARGIN + UIConstants.HEADER_HEIGHT + 6 + UIConstants.TURN_INDICATOR_HEIGHT/2, 5)
         else
             love.graphics.setColor(0.4, 0.4, 0.4)
-            love.graphics.circle("line", x, UI_MARGIN + HEADER_HEIGHT + 6 + TURN_INDICATOR_HEIGHT/2, 5)
+            love.graphics.circle("line", x, UIConstants.UI_MARGIN + UIConstants.HEADER_HEIGHT + 6 + UIConstants.TURN_INDICATOR_HEIGHT/2, 5)
         end
     end
     
     -- Dés et bouton
-    local weatherTop = UI_MARGIN + HEADER_HEIGHT + 6 + TURN_INDICATOR_HEIGHT + 6
+    local weatherTop = UIConstants.UI_MARGIN + UIConstants.HEADER_HEIGHT + 6 + UIConstants.TURN_INDICATOR_HEIGHT + 6
     love.graphics.setColor(0.8, 0.9, 0.95)
-    love.graphics.rectangle("fill", UI_MARGIN, weatherTop, 580 * 0.6, WEATHER_SECTION_HEIGHT)
+    love.graphics.rectangle("fill", 
+                           UIConstants.UI_MARGIN, 
+                           weatherTop, 
+                           UIConstants.MAIN_PANEL_WIDTH * scale, 
+                           UIConstants.WEATHER_SECTION_HEIGHT)
     
     -- Dé soleil
-    local dieX1 = UI_MARGIN + (580 * 0.6) * 0.4
+    local dieX1 = UIConstants.UI_MARGIN + (UIConstants.MAIN_PANEL_WIDTH * scale) * 0.4
     love.graphics.setColor(1, 0.8, 0)
-    love.graphics.rectangle("fill", dieX1, weatherTop + 3, DIE_SIZE, DIE_SIZE, DIE_CORNER_RADIUS)
+    love.graphics.rectangle("fill", 
+                           dieX1, 
+                           weatherTop + 3, 
+                           UIConstants.DIE_SIZE * scale, 
+                           UIConstants.DIE_SIZE * scale, 
+                           UIConstants.DIE_CORNER_RADIUS)
     love.graphics.setColor(0, 0, 0)
-    love.graphics.print(self.sunDieValue, dieX1 + 9, weatherTop + 6, 0, TEXT_SCALE, TEXT_SCALE)
-    love.graphics.print(Localization.getText("ui.soleil"), dieX1 + 3, weatherTop + 18, 0, TEXT_SCALE, TEXT_SCALE)
+    love.graphics.print(self.sunDieValue, 
+                       dieX1 + 9, 
+                       weatherTop + 6, 
+                       0, scale, scale)
+    love.graphics.print(Localization.getText("ui.soleil"), 
+                       dieX1 + 3, 
+                       weatherTop + 18, 
+                       0, scale, scale)
     
     -- Dé pluie
-    local dieX2 = UI_MARGIN + (580 * 0.6) * 0.55
+    local dieX2 = UIConstants.UI_MARGIN + (UIConstants.MAIN_PANEL_WIDTH * scale) * 0.55
     love.graphics.setColor(0.6, 0.8, 1)
-    love.graphics.rectangle("fill", dieX2, weatherTop + 3, DIE_SIZE, DIE_SIZE, DIE_CORNER_RADIUS)
+    love.graphics.rectangle("fill", 
+                           dieX2, 
+                           weatherTop + 3, 
+                           UIConstants.DIE_SIZE * scale, 
+                           UIConstants.DIE_SIZE * scale, 
+                           UIConstants.DIE_CORNER_RADIUS)
     love.graphics.setColor(0, 0, 0)
-    love.graphics.print(self.rainDieValue, dieX2 + 9, weatherTop + 6, 0, TEXT_SCALE, TEXT_SCALE)
-    love.graphics.print(Localization.getText("ui.pluie"), dieX2 + 6, weatherTop + 18, 0, TEXT_SCALE, TEXT_SCALE)
+    love.graphics.print(self.rainDieValue, 
+                       dieX2 + 9, 
+                       weatherTop + 6, 
+                       0, scale, scale)
+    love.graphics.print(Localization.getText("ui.pluie"), 
+                       dieX2 + 6, 
+                       weatherTop + 18, 
+                       0, scale, scale)
     
     -- Bouton fin de tour
-    local buttonX = UI_MARGIN + (580 * 0.6) * 0.8
+    local buttonX = UIConstants.UI_MARGIN + (UIConstants.MAIN_PANEL_WIDTH * scale) * 0.8
     love.graphics.setColor(0.6, 0.8, 0.6)
-    love.graphics.rectangle("fill", buttonX, weatherTop + 6, BUTTON_WIDTH, BUTTON_HEIGHT, 3)
+    love.graphics.rectangle("fill", 
+                           buttonX, 
+                           weatherTop + 6, 
+                           UIConstants.BUTTON_WIDTH * scale, 
+                           UIConstants.BUTTON_HEIGHT * scale, 
+                           3)
     love.graphics.setColor(0, 0, 0)
-    love.graphics.print(Localization.getText("ui.fin_tour"), buttonX + 3, weatherTop + 12, 0, TEXT_SCALE, TEXT_SCALE)
+    love.graphics.print(Localization.getText("ui.fin_tour"), 
+                       buttonX + 3, 
+                       weatherTop + 12, 
+                       0, scale, scale)
     
     -- Score
     love.graphics.setColor(0, 0, 0)
-    love.graphics.print(Localization.getText("ui.score") .. ": " .. self.score .. "/" .. self.objective, UI_MARGIN, weatherTop + WEATHER_SECTION_HEIGHT + 6, 0, TEXT_SCALE, TEXT_SCALE)
+    love.graphics.print(Localization.getText("ui.score") .. ": " .. self.score .. "/" .. self.objective, 
+                       UIConstants.UI_MARGIN, 
+                       weatherTop + UIConstants.WEATHER_SECTION_HEIGHT + 6, 
+                       0, scale, scale)
     
     -- Dessin du jardin avec son renderer dédié
     -- Transmission de la position du jardin et de la taille des cellules
-    gardenRenderer:draw(self.garden, UI_MARGIN, GARDEN_TOP_MARGIN, CELL_SIZE)
+    gardenRenderer:draw(self.garden, 
+                       UIConstants.UI_MARGIN, 
+                       UIConstants.GARDEN_TOP_MARGIN * scale, 
+                       UIConstants.CELL_SIZE * scale)
 end
 
 function GameState:mousepressed(x, y, button)
-    -- Vérifier si le bouton fin de tour a été cliqué
-    local weatherTop = UI_MARGIN + HEADER_HEIGHT + 6 + TURN_INDICATOR_HEIGHT + 6
-    local buttonX = UI_MARGIN + (580 * 0.6) * 0.8
+    -- Facteur d'échelle pour la réduction des éléments d'interface
+    local scale = UIConstants.CARD_SCALE_WHEN_DRAGGED
     
-    if button == 1 and x >= buttonX and x <= buttonX + BUTTON_WIDTH and 
-                       y >= weatherTop + 6 and y <= weatherTop + 6 + BUTTON_HEIGHT then
+    -- Vérifier si le bouton fin de tour a été cliqué
+    local weatherTop = UIConstants.UI_MARGIN + UIConstants.HEADER_HEIGHT + 6 + UIConstants.TURN_INDICATOR_HEIGHT + 6
+    local buttonX = UIConstants.UI_MARGIN + (UIConstants.MAIN_PANEL_WIDTH * scale) * 0.8
+    
+    if button == 1 and x >= buttonX and x <= buttonX + UIConstants.BUTTON_WIDTH * scale and 
+                       y >= weatherTop + 6 and y <= weatherTop + 6 + UIConstants.BUTTON_HEIGHT * scale then
         self:nextTurn()
     end
     
     -- Vérifier si une cellule du jardin a été cliquée
-    local cellX = math.floor((x - UI_MARGIN) / CELL_SIZE) + 1
-    local cellY = math.floor((y - GARDEN_TOP_MARGIN) / CELL_SIZE) + 1
+    local gardenX = UIConstants.UI_MARGIN
+    local gardenY = UIConstants.GARDEN_TOP_MARGIN * scale
+    local cellSize = UIConstants.CELL_SIZE * scale
+    
+    local cellX = math.floor((x - gardenX) / cellSize) + 1
+    local cellY = math.floor((y - gardenY) / cellSize) + 1
     
     if cellX >= 1 and cellX <= self.garden.width and 
        cellY >= 1 and cellY <= self.garden.height then

--- a/src/ui/constants.lua
+++ b/src/ui/constants.lua
@@ -1,0 +1,47 @@
+-- constants.lua
+-- Définition des constantes pour l'interface utilisateur basée sur les pixels
+-- Les valeurs sont basées sur une résolution de référence HD (1920x1080)
+
+local constants = {}
+
+-- Résolution de référence pour le développement (déjà définie dans ScaleManager)
+constants.REFERENCE_WIDTH = 1920
+constants.REFERENCE_HEIGHT = 1080
+
+-- Marges et espacements standards
+constants.UI_MARGIN = 10     -- Marge générale de l'interface
+constants.UI_PADDING = 20    -- Espacement interne des éléments
+constants.CORNER_RADIUS = 5  -- Rayon des coins arrondis standard
+
+-- Dimensions des zones principales de l'écran
+constants.HEADER_HEIGHT = 40                        -- Hauteur de la barre de titre
+constants.TURN_INDICATOR_HEIGHT = 30                -- Hauteur de l'indicateur de tour
+constants.WEATHER_SECTION_HEIGHT = 50               -- Hauteur de la section météo
+constants.GARDEN_TOP_MARGIN = 160                   -- Marge supérieure du potager
+constants.CELL_SIZE = 70                            -- Taille d'une cellule du potager
+constants.MAIN_PANEL_WIDTH = 1440                   -- 3/4 de la largeur totale (pour layout principal)
+constants.INFO_PANEL_WIDTH = 480                    -- 1/4 de la largeur totale (pour colonne info)
+
+-- Dimensions des éléments interactifs
+constants.DIE_SIZE = 40                             -- Taille des dés météo
+constants.DIE_CORNER_RADIUS = 6                     -- Rayon des coins arrondis des dés
+constants.BUTTON_WIDTH = 80                         -- Largeur standard des boutons
+constants.BUTTON_HEIGHT = 30                        -- Hauteur standard des boutons
+
+-- Dimensions des cartes
+constants.CARD_WIDTH = 108                          -- Largeur d'une carte
+constants.CARD_HEIGHT = 180                         -- Hauteur d'une carte
+constants.CARD_CORNER_RADIUS = 5                    -- Rayon des coins arrondis des cartes
+constants.CARD_HEADER_HEIGHT = 27                   -- Hauteur de l'en-tête d'une carte
+constants.CARD_TEXT_PADDING_X = 10                  -- Marge horizontale du texte dans une carte
+constants.CARD_TEXT_LINE_HEIGHT = 18                -- Hauteur de ligne du texte dans une carte
+constants.CARD_SCALE_WHEN_DRAGGED = 0.6             -- Taille réduite pour le drag & drop
+
+-- Constantes d'animation
+constants.DRAG_ANIMATION_DURATION = 0.3             -- Durée de l'animation de drag en secondes
+constants.RETURN_ANIMATION_DURATION = 0.3           -- Durée de l'animation de retour en main
+
+-- Autres constantes
+constants.TEXT_SCALE = 1.0                          -- Échelle de base du texte (sera ajustée par ScaleManager)
+
+return constants

--- a/src/utils/scale_manager.lua
+++ b/src/utils/scale_manager.lua
@@ -1,7 +1,8 @@
 -- Gestionnaire d'échelle pour adapter l'interface à différentes tailles d'écran
 local ScaleManager = {}
 
--- Dimensions de référence pour la conception (1920x1080 HD)
+-- Les dimensions de référence sont maintenant importées depuis UIConstants
+-- mais on les garde ici aussi pour l'initialisation
 ScaleManager.referenceWidth = 1920
 ScaleManager.referenceHeight = 1080
 
@@ -153,6 +154,19 @@ function ScaleManager.resizeWindow(width, height)
     ScaleManager.scale = math.min(ScaleManager.scaleX, ScaleManager.scaleY)
     
     print("ScaleManager: Redimensionnement à " .. width .. "x" .. height .. " (échelle: " .. ScaleManager.scale .. ")")
+end
+
+-- Fonction utilitaire pour convertir une valeur en pixels vers des valeurs adaptées à l'échelle actuelle
+function ScaleManager.pixelToScale(pixelValue)
+    return pixelValue * ScaleManager.scale
+end
+
+-- Fonction pour récupérer la valeur en pixels d'origine (non mise à l'échelle)
+function ScaleManager.scaleToPixel(scaledValue)
+    if ScaleManager.scale == 0 then
+        return scaledValue -- Éviter division par zéro
+    end
+    return scaledValue / ScaleManager.scale
 end
 
 return ScaleManager


### PR DESCRIPTION
## Description
Cette Pull Request propose de centraliser et de standardiser la définition des positions et dimensions en pixels pour l'interface utilisateur, en utilisant la référence HD déjà présente dans le ScaleManager (1920x1080).

## Problème
Actuellement, les dimensions et positions des éléments d'interface sont:
1. Dispersées dans différents fichiers (drag_drop.lua, game_state.lua)
2. Certaines valeurs sont pré-calculées manuellement avec un facteur de 0.6
3. Manque de centralisation qui rend les modifications et la maintenance difficiles

## Solution proposée
1. Centraliser toutes les valeurs de position et de dimension dans `src/ui/constants.lua`
2. Utiliser les valeurs en pixels basées sur la référence HD (1920x1080) sans pré-réduction manuelle
3. Laisser le ScaleManager gérer automatiquement l'adaptation à différentes résolutions

## Modifications
- Création de `src/ui/constants.lua` pour centraliser toutes les constantes d'UI
- Refactorisation des constantes dans les fichiers existants pour utiliser cette nouvelle source
- Modification du ScaleManager pour ajouter des méthodes utilitaires de conversion
- Ajout d'une documentation détaillée sur l'utilisation du système

## Impact sur le code
Cette modification améliore la maintenabilité tout en gardant le même rendu visuel. Elle facilite les futurs ajustements d'interface en concentrant les définitions de dimensions dans un seul fichier de référence.

## Tests effectués
- Vérification des valeurs de mise à l'échelle sur différentes résolutions
- Contrôle de la consistance visuelle avant/après modification