### PR TITLE
Unification de constants.lua et config.lua en game_config.lua

### DIFF
--- a/src/utils/config.lua
+++ b/src/utils/config.lua
@@ -1,57 +1,29 @@
--- Configuration du jeu
-local Constants = require('src.utils.constants')
+-- src/utils/config.lua
+-- COMPATIBILITÉ: Ce module est maintenu pour la rétrocompatibilité et redirige vers game_config.lua
 
+local GameConfig = require('src.utils.game_config')
+
+-- Message avertissant de la dépréciation
+print("AVERTISSEMENT: Le module 'config.lua' est déprécié. Utilisez 'game_config.lua' à la place.")
+
+-- Créer une structure qui imite l'ancien format de config
 return {
     -- Paramètres généraux
-    baseTurnsPerLevel = 8,
-    seasonsPerLevel = 4,
-    turnsPerSeason = 2,
+    baseTurnsPerLevel = GameConfig.GAME_PARAMS.baseTurnsPerLevel,
+    seasonsPerLevel = GameConfig.GAME_PARAMS.seasonsPerLevel,
+    turnsPerSeason = GameConfig.GAME_PARAMS.turnsPerSeason,
     
     -- Plages de dés par saison
-    diceRanges = {
-        [Constants.SEASON.SPRING] = {
-            sun = {min = -1, max = 5},
-            rain = {min = 2, max = 6}
-        },
-        [Constants.SEASON.SUMMER] = {
-            sun = {min = 3, max = 8},
-            rain = {min = 0, max = 4}
-        },
-        [Constants.SEASON.AUTUMN] = {
-            sun = {min = -2, max = 4},
-            rain = {min = 1, max = 6}
-        },
-        [Constants.SEASON.WINTER] = {
-            sun = {min = -3, max = 2},
-            rain = {min = 0, max = 4}
-        }
-    },
+    diceRanges = GameConfig.DICE_RANGES,
     
     -- Objectifs et récompenses
-    baseScoreObjective = 100,
+    baseScoreObjective = GameConfig.GAME_PARAMS.baseScoreObjective,
     
     -- Paramètres jeu
-    initialDeckSize = 15,
-    initialHandSize = 5,
-    initialGardenSize = {width = 3, height = 2},
+    initialDeckSize = GameConfig.GAME_PARAMS.initialDeckSize,
+    initialHandSize = GameConfig.GAME_PARAMS.initialHandSize,
+    initialGardenSize = GameConfig.GAME_PARAMS.initialGardenSize,
     
     -- Propriétés plantes
-    plantConfigs = {
-        [Constants.PLANT_FAMILY.BRASSIKA] = {
-            frostThreshold = -5,
-            sunToSprout = 3,
-            rainToSprout = 4,
-            sunToFruit = 6,
-            rainToFruit = 8,
-            baseScore = 20
-        },
-        [Constants.PLANT_FAMILY.SOLANA] = {
-            frostThreshold = -2,
-            sunToSprout = 5,
-            rainToSprout = 3,
-            sunToFruit = 10,
-            rainToFruit = 6,
-            baseScore = 30
-        }
-    }
+    plantConfigs = GameConfig.PLANT_CONFIG
 }

--- a/src/utils/configuration.md
+++ b/src/utils/configuration.md
@@ -1,0 +1,58 @@
+# Configuration et Constantes de Fructidor
+
+## Changement de structure
+
+Auparavant, la configuration de Fructidor était répartie entre deux fichiers:
+- `constants.lua` : contenant les énumérations et références symboliques
+- `config.lua` : contenant les valeurs de jeu ajustables
+
+Cette séparation créait une confusion et un chevauchement conceptuel.
+
+## Nouvelle structure unifiée
+
+Désormais, toute la configuration est centralisée dans un seul module:
+
+### `game_config.lua`
+
+Ce module est divisé en trois sections principales:
+
+1. **Énumérations et constantes**: Valeurs symboliques immuables
+   - Saisons, familles de plantes, couleurs, stades de croissance, etc.
+
+2. **Paramètres de jeu**: Valeurs ajustables pour l'équilibrage
+   - Dés, scores, configurations des plantes, etc.
+
+3. **UI et éléments graphiques**: Paramètres visuels et dimensions
+   - Tailles de cartes, couleurs d'interface, etc.
+
+## Migration de votre code
+
+Pour mettre à jour votre code existant:
+
+```lua
+-- Avant (utilisant les deux modules séparés)
+local Constants = require('src.utils.constants')
+local Config = require('src.utils.config')
+
+local season = Constants.SEASON.SPRING
+local diceRange = Config.diceRanges[season]
+
+-- Après (utilisant le module unifié)
+local GameConfig = require('src.utils.game_config')
+
+local season = GameConfig.SEASON.SPRING
+local diceRange = GameConfig.DICE_RANGES[season]
+```
+
+## Modules de compatibilité
+
+Pour faciliter la transition, les anciens modules `constants.lua` et `config.lua` sont maintenus temporairement comme des wrappers redirigeant vers `game_config.lua`.
+
+Cependant, il est recommandé de migrer votre code vers le nouveau module dès que possible, car ces wrappers seront supprimés dans une version future.
+
+## Avantages de cette refonte
+
+- **Clarté conceptuelle**: Un seul endroit pour toutes les configurations
+- **Cohérence accrue**: Organisation logique par type de paramètres
+- **Maintenance simplifiée**: Facilité pour retrouver et modifier les paramètres
+- **Évolution structurée**: Nouvelles sections peuvent être ajoutées proprement

--- a/src/utils/constants.lua
+++ b/src/utils/constants.lua
@@ -1,90 +1,23 @@
 -- src/utils/constants.lua
--- Module contenant toutes les constantes d'énumération pour Fructidor
+-- COMPATIBILITÉ: Ce module est maintenu pour la rétrocompatibilité et redirige vers game_config.lua
 
+local GameConfig = require('src.utils.game_config')
+
+-- Message avertissant de la dépréciation
+print("AVERTISSEMENT: Le module 'constants.lua' est déprécié. Utilisez 'game_config.lua' à la place.")
+
+-- Créer une copie des sections constantes de GameConfig
 local Constants = {}
 
--- Saisons
-Constants.SEASON = {
-  SPRING = "SPRING",
-  SUMMER = "SUMMER", 
-  AUTUMN = "AUTUMN",
-  WINTER = "WINTER"
-}
-
--- Familles de plantes
-Constants.PLANT_FAMILY = {
-  BRASSIKA = "BRASSIKA",
-  SOLANA = "SOLANA",
-  FABA = "FABA",
-  KUKURBITA = "KUKURBITA"
-}
-
--- Couleurs
-Constants.COLOR = {
-  GREEN = "GREEN",
-  RED = "RED", 
-  YELLOW = "YELLOW",
-  BLUE = "BLUE"
-}
-
--- Stades de croissance des plantes (standardisé)
-Constants.GROWTH_STAGE = {
-  SEED = "SEED",         -- Graine
-  SPROUT = "SPROUT",     -- Pousse (rename pour plus de cohérence)
-  FRUIT = "FRUIT"        -- Fruit (rename pour cohérence avec le renderer)
-}
-
--- Types de cartes
-Constants.CARD_TYPE = {
-  PLANT = "PLANT",
-  OBJECT = "OBJECT"
-}
-
--- Types d'objets
-Constants.OBJECT_TYPE = {
-  STANDALONE = "STANDALONE",
-  COMBINABLE = "COMBINABLE"
-}
-
--- États d'une case du jardin
-Constants.CELL_STATE = {
-  EMPTY = "EMPTY",
-  OCCUPIED = "OCCUPIED",
-  DAMAGED = "DAMAGED"
-}
-
--- Types d'événements
-Constants.EVENT_TYPE = {
-  WEATHER = "WEATHER",
-  EXHIBITION = "EXHIBITION",
-  NATURAL_DANGER = "NATURAL_DANGER",
-  ECONOMIC = "ECONOMIC"
-}
-
--- Contraintes d'événements
-Constants.CONSTRAINT_TYPE = {
-  SUN_MODIFIER = "SUN_MODIFIER",
-  RAIN_MODIFIER = "RAIN_MODIFIER",
-  FROST_RISK = "FROST_RISK",
-  FAMILY_BONUS = "FAMILY_BONUS",
-  COLOR_BONUS = "COLOR_BONUS",
-  TIME_LIMIT = "TIME_LIMIT"
-}
-
--- Constantes graphiques centralisées
-Constants.UI = {
-  -- Dimensions des cartes (centralisé)
-  CARD = {
-    WIDTH = 65,
-    HEIGHT = 108,
-    CORNER_RADIUS = 3,
-    HEADER_HEIGHT = 16,
-    TEXT_SCALE = 0.84
-  },
-  -- Couleurs standards (centralisables ultérieurement)
-  COLORS = {
-    -- ... à compléter au besoin
-  }
-}
+Constants.SEASON = GameConfig.SEASON
+Constants.PLANT_FAMILY = GameConfig.PLANT_FAMILY
+Constants.COLOR = GameConfig.COLOR
+Constants.GROWTH_STAGE = GameConfig.GROWTH_STAGE
+Constants.CARD_TYPE = GameConfig.CARD_TYPE
+Constants.OBJECT_TYPE = GameConfig.OBJECT_TYPE
+Constants.CELL_STATE = GameConfig.CELL_STATE
+Constants.EVENT_TYPE = GameConfig.EVENT_TYPE
+Constants.CONSTRAINT_TYPE = GameConfig.CONSTRAINT_TYPE
+Constants.UI = GameConfig.UI
 
 return Constants

--- a/src/utils/game_config.lua
+++ b/src/utils/game_config.lua
@@ -1,0 +1,155 @@
+-- src/utils/game_config.lua
+-- Module unifié contenant toutes les constantes et configurations du jeu
+
+local GameConfig = {}
+
+--[[
+  SECTION 1: ÉNUMÉRATIONS ET CONSTANTES
+  Ces valeurs sont des références symboliques qui ne changent pas
+--]]
+
+-- Saisons
+GameConfig.SEASON = {
+  SPRING = "SPRING",
+  SUMMER = "SUMMER", 
+  AUTUMN = "AUTUMN",
+  WINTER = "WINTER"
+}
+
+-- Familles de plantes
+GameConfig.PLANT_FAMILY = {
+  BRASSIKA = "BRASSIKA",
+  SOLANA = "SOLANA",
+  FABA = "FABA",
+  KUKURBITA = "KUKURBITA"
+}
+
+-- Couleurs
+GameConfig.COLOR = {
+  GREEN = "GREEN",
+  RED = "RED", 
+  YELLOW = "YELLOW",
+  BLUE = "BLUE"
+}
+
+-- Stades de croissance des plantes
+GameConfig.GROWTH_STAGE = {
+  SEED = "SEED",         -- Graine
+  SPROUT = "SPROUT",     -- Pousse
+  FRUIT = "FRUIT"        -- Fruit
+}
+
+-- Types de cartes
+GameConfig.CARD_TYPE = {
+  PLANT = "PLANT",
+  OBJECT = "OBJECT"
+}
+
+-- Types d'objets
+GameConfig.OBJECT_TYPE = {
+  STANDALONE = "STANDALONE",
+  COMBINABLE = "COMBINABLE"
+}
+
+-- États d'une case du jardin
+GameConfig.CELL_STATE = {
+  EMPTY = "EMPTY",
+  OCCUPIED = "OCCUPIED",
+  DAMAGED = "DAMAGED"
+}
+
+-- Types d'événements
+GameConfig.EVENT_TYPE = {
+  WEATHER = "WEATHER",
+  EXHIBITION = "EXHIBITION",
+  NATURAL_DANGER = "NATURAL_DANGER",
+  ECONOMIC = "ECONOMIC"
+}
+
+-- Contraintes d'événements
+GameConfig.CONSTRAINT_TYPE = {
+  SUN_MODIFIER = "SUN_MODIFIER",
+  RAIN_MODIFIER = "RAIN_MODIFIER",
+  FROST_RISK = "FROST_RISK",
+  FAMILY_BONUS = "FAMILY_BONUS",
+  COLOR_BONUS = "COLOR_BONUS",
+  TIME_LIMIT = "TIME_LIMIT"
+}
+
+--[[
+  SECTION 2: PARAMÈTRES DE JEU
+  Ces valeurs peuvent être ajustées pour régler l'équilibrage
+--]]
+
+-- Paramètres généraux
+GameConfig.GAME_PARAMS = {
+  baseTurnsPerLevel = 8,
+  seasonsPerLevel = 4,
+  turnsPerSeason = 2,
+  baseScoreObjective = 100,
+  initialDeckSize = 15,
+  initialHandSize = 5,
+  initialGardenSize = {width = 3, height = 2}
+}
+
+-- Plages de dés par saison
+GameConfig.DICE_RANGES = {
+  [GameConfig.SEASON.SPRING] = {
+    sun = {min = -1, max = 5},
+    rain = {min = 2, max = 6}
+  },
+  [GameConfig.SEASON.SUMMER] = {
+    sun = {min = 3, max = 8},
+    rain = {min = 0, max = 4}
+  },
+  [GameConfig.SEASON.AUTUMN] = {
+    sun = {min = -2, max = 4},
+    rain = {min = 1, max = 6}
+  },
+  [GameConfig.SEASON.WINTER] = {
+    sun = {min = -3, max = 2},
+    rain = {min = 0, max = 4}
+  }
+}
+
+-- Propriétés des plantes par famille
+GameConfig.PLANT_CONFIG = {
+  [GameConfig.PLANT_FAMILY.BRASSIKA] = {
+    frostThreshold = -5,
+    sunToSprout = 3,
+    rainToSprout = 4,
+    sunToFruit = 6,
+    rainToFruit = 8,
+    baseScore = 20
+  },
+  [GameConfig.PLANT_FAMILY.SOLANA] = {
+    frostThreshold = -2,
+    sunToSprout = 5,
+    rainToSprout = 3,
+    sunToFruit = 10,
+    rainToFruit = 6,
+    baseScore = 30
+  }
+}
+
+--[[
+  SECTION 3: UI ET ÉLÉMENTS GRAPHIQUES
+--]]
+
+-- Constantes UI
+GameConfig.UI = {
+  -- Dimensions des cartes
+  CARD = {
+    WIDTH = 65,
+    HEIGHT = 108,
+    CORNER_RADIUS = 3,
+    HEADER_HEIGHT = 16,
+    TEXT_SCALE = 0.84
+  },
+  -- Palette de couleurs pour les différents éléments d'interface
+  COLORS = {
+    -- À compléter selon les besoins
+  }
+}
+
+return GameConfig


### PR DESCRIPTION
## Description du problème
Le projet actuel utilise deux fichiers distincts mais chevauchants pour la configuration : `constants.lua` et `config.lua`. Cette séparation artificielle crée de la confusion, rend le code plus difficile à comprendre et complique la maintenance des valeurs de configuration.

## Solution proposée
Cette PR unifie les deux modules en un seul fichier bien structuré `game_config.lua` organisé en sections logiques :

1. **Énumérations et constantes**: Valeurs symboliques immuables
2. **Paramètres de jeu**: Valeurs ajustables pour l'équilibrage
3. **UI et éléments graphiques**: Paramètres visuels et dimensions

## Avantages
- **Clarté conceptuelle**: Un seul endroit pour toutes les configurations
- **Cohérence accrue**: Organisation logique par type de paramètres
- **Maintenance simplifiée**: Facilité pour retrouver et modifier les paramètres
- **Évolutivité**: Structure claire pour ajouter de futures configurations

## Approche de transition
Pour assurer une transition en douceur :
- Le nouveau fichier `game_config.lua` contient toutes les configurations fusionnées
- Les anciens fichiers `constants.lua` et `config.lua` sont maintenus temporairement comme wrappers qui redirigent vers le nouveau module
- Une documentation détaillée a été ajoutée pour guider la migration

## Impacts sur le code existant
- Aucun impact immédiat grâce aux wrappers de compatibilité
- Possibilité de migrer progressivement vers le nouveau module

## Tests effectués
- Vérification de la compatibilité des wrappers avec le code existant
- Validation de la structure organisationnelle du nouveau module
- Test de lecture et modification de paramètres via la nouvelle structure

## Prochaines étapes
Une fois cette PR approuvée et le code migré, les anciens modules pourront être complètement supprimés dans une future PR.