### PR TITLE
Simplifier et unifier la gestion des dépendances

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,34 @@ Cette version du projet est basée sur les principes KISS (Keep It Simple, Stupi
 ### Améliorations récentes
 
 - **Simplification de l'architecture**: Suppression des couches inutiles et des abstractions excessives
-- **Standardisation de la gestion des dépendances**: Utilisation d'un seul système (Services)
+- **Adoption d'un modèle unique d'injection de dépendances**: Utilisation cohérente de l'injection directe par constructeur
 - **Cohérence de configuration**: Centralisation dans un seul module
 - **Système d'animation simplifié**: Interface plus réactive et code plus maintenable
 - **Tests unitaires clarifiés**: Structure de tests cohérente et extensible
+
+## Gestion des dépendances
+
+Le projet utilise désormais un modèle unifié d'injection de dépendances:
+
+1. Les modules reçoivent leurs dépendances via leurs constructeurs `new()`
+2. Les dépendances sont explicitement passées aux composants qui en ont besoin
+3. Le système global de Services est maintenu pour une transition en douceur, mais est déprécié
+
+Exemple d'utilisation:
+
+```lua
+-- Création d'un module avec ses dépendances
+local cardSystem = CardSystem.new({
+    scaleManager = ScaleManager
+})
+
+-- Injection du module comme dépendance d'un autre module
+local gameState = GameState.new({
+    cardSystem = cardSystem,
+    garden = garden,
+    scaleManager = ScaleManager
+})
+```
 
 ## Comment exécuter le projet
 
@@ -50,5 +74,6 @@ Pour participer au développement:
 
 1. Suivez les règles de nommage et d'organisation du code
 2. Maintenez la simplicité du code en évitant les abstractions excessives
-3. Écrivez des tests pour les nouvelles fonctionnalités
-4. Suivez le processus de contribution défini dans le document `docs/Processus de Contribution pour Fructidor.md`
+3. Utilisez l'injection de dépendances directe via le constructeur
+4. Écrivez des tests pour les nouvelles fonctionnalités
+5. Suivez le processus de contribution défini dans le document `docs/Processus de Contribution pour Fructidor.md`

--- a/main.lua
+++ b/main.lua
@@ -6,7 +6,7 @@ local Garden = require('src.entities.garden')
 local ScaleManager = require('src.utils.scale_manager')
 local UIManager = require('src.ui.ui_manager')
 local GardenRenderer = require('src.ui.garden_renderer')
-local ServiceSetup = require('src.utils.service_setup')
+local Services = require('src.utils.services') -- Maintenu pour compatibilité
 
 -- Module principal pour stocker les références localement
 local Game = {
@@ -31,7 +31,7 @@ function love.load(arg)
         return
     end
     
-    -- Créer les instances principales
+    -- Créer les instances principales en utilisant l'injection de dépendances directe
     local garden = Garden.new(3, 2)
     local gardenRenderer = GardenRenderer.new()
     
@@ -67,6 +67,9 @@ function love.load(arg)
         end
     })
     
+    -- Compléter les dépendances manquantes
+    dragDrop.dependencies.uiManager = uiManager
+    
     -- Stocker les références localement 
     Game.gameState = gameState
     Game.cardSystem = cardSystem
@@ -74,8 +77,9 @@ function love.load(arg)
     Game.garden = garden
     Game.uiManager = uiManager
     
-    -- Initialiser les services avec nos instances
-    ServiceSetup.initialize({
+    -- Initialiser les services pour la compatibilité avec le code existant
+    -- Cette partie sera éventuellement supprimée dans une future version
+    Services.initialize({
         GameState = gameState,
         CardSystem = cardSystem,
         Garden = garden,

--- a/src/ui/drag_drop.lua
+++ b/src/ui/drag_drop.lua
@@ -1,5 +1,4 @@
 -- Système de Drag & Drop simplifié
-local Services = require('src.utils.services')
 local Constants = require('src.utils.game_config')
 
 local DragDrop = {}
@@ -95,9 +94,9 @@ function DragDrop:stopDrag(garden)
     end
     
     local placed = false
+    local uiManager = self.dependencies.uiManager
     
     -- Récupérer le GardenDisplay
-    local uiManager = self.dependencies.uiManager or Services.get("UIManager")
     local gardenDisplay = uiManager and uiManager.components and uiManager.components.gardenDisplay
     
     -- Trouver la cellule sous la carte
@@ -129,7 +128,7 @@ function DragDrop:stopDrag(garden)
             if isInside then
                 -- Tenter de placer la plante
                 if not garden.grid[y][x].plant then
-                    local cardSystem = self.dependencies.cardSystem or Services.get("CardSystem")
+                    local cardSystem = self.dependencies.cardSystem
                     if self.cardIndex and cardSystem then
                         placed = cardSystem:playCard(self.cardIndex, garden, x, y)
                     end

--- a/src/utils/service_setup.lua
+++ b/src/utils/service_setup.lua
@@ -1,38 +1,16 @@
 -- Configuration du système de services pour Fructidor
+-- DÉPRÉCIÉ: Ce module est maintenu uniquement pour compatibilité
+-- et sera supprimé dans une version future.
+-- Utilisez l'injection de dépendances directe via le constructeur à la place.
+
 local Services = require('src.utils.services')
-local PlantRenderer = require('src.ui.plant_renderer')
-local GardenRenderer = require('src.ui.garden_renderer')
-local CardRenderer = require('src.ui.card_renderer')
 
 -- Module pour initialiser tous les services au démarrage de l'application
 local ServiceSetup = {}
 
--- Enregistrer les factories pour les renderers
-function ServiceSetup.registerFactories()
-    -- Enregistrer les renderers en tant que singletons via des factories
-    Services.registerFactory("PlantRenderer", function()
-        return PlantRenderer.new()
-    end)
-    
-    Services.registerFactory("GardenRenderer", function()
-        return GardenRenderer.new()
-    end)
-    
-    Services.registerFactory("CardRenderer", function()
-        return CardRenderer.new()
-    end)
-    
-    -- Autres factories peuvent être ajoutées ici à l'avenir
-    
-    return true
-end
-
 -- Fonction d'initialisation à appeler une seule fois au démarrage
 function ServiceSetup.initialize(systems)
     systems = systems or {}
-    
-    -- Enregistrer les factories
-    ServiceSetup.registerFactories()
     
     -- Enregistrer les instances des systèmes principaux
     local instances = {}
@@ -43,6 +21,7 @@ function ServiceSetup.initialize(systems)
     if systems.gameState then instances.GameState = systems.gameState end
     if systems.dragDrop then instances.DragDrop = systems.dragDrop end
     if systems.uiManager then instances.UIManager = systems.uiManager end
+    if systems.gardenRenderer then instances.GardenRenderer = systems.gardenRenderer end
     
     -- Ajouter le ScaleManager s'il est fourni et initialisé
     if systems.scaleManager then

--- a/src/utils/services.lua
+++ b/src/utils/services.lua
@@ -1,12 +1,10 @@
--- Services - Système de gestion des dépendances standardisé pour Fructidor
--- Ce module remplace DependencyContainer en proposant une solution plus simple
+-- Services - Système de gestion des dépendances simplifié pour Fructidor
+-- Ce module est déprécié et sera supprimé dans une version future.
+-- Utilisez l'injection de dépendances directe à la place.
 
 local Services = {
     -- Stockage des services
     _services = {},
-    
-    -- Stockage des factories
-    _factories = {},
     
     -- Indique si les services ont été initialisés
     initialized = false
@@ -22,55 +20,14 @@ function Services.initialize(instances)
 end
 
 -- Récupère un service par son nom
--- Si le service n'existe pas encore mais qu'une factory est enregistrée,
--- crée et stocke l'instance à la demande (lazy loading)
 function Services.get(name)
-    -- Si l'instance existe déjà, la retourner
-    if Services._services[name] then
-        return Services._services[name]
-    end
-    
-    -- Vérifier si une factory est enregistrée
-    local factory = Services._factories[name]
-    if factory then
-        -- Créer et stocker l'instance
-        local instance = factory()
-        Services._services[name] = instance
-        return instance
-    end
-    
-    -- Renvoyer nil si aucun service ni factory n'est trouvé
-    return nil
+    return Services._services[name]
 end
 
 -- Enregistre un service
 function Services.register(name, service)
     Services._services[name] = service
     return service
-end
-
--- Enregistre une factory pour créer le service à la demande
-function Services.registerFactory(name, factory)
-    if type(factory) ~= "function" then
-        error("Factory doit être une fonction")
-    end
-    
-    Services._factories[name] = factory
-    -- Réinitialiser l'instance si elle existait
-    Services._services[name] = nil
-    
-    return Services
-end
-
--- Vérifie si un service existe ou peut être créé
-function Services.exists(name)
-    return Services._services[name] ~= nil or Services._factories[name] ~= nil
-end
-
--- Réinitialise un service spécifique
-function Services.reset(name)
-    Services._services[name] = nil
-    return Services
 end
 
 -- Réinitialise tous les services (utile pour les tests)


### PR DESCRIPTION
## Description du problème

Le code actuel présente une double approche pour la gestion des dépendances :
1. Injection par constructeur (`new()`)
2. Service Locator global (`Services.get()`)

Cette double approche crée une confusion sur la manière "correcte" d'accéder aux dépendances et complique le flux de données dans l'application.

## Solution proposée

Cette PR simplifie la gestion des dépendances en uniformisant l'approche :
- Utilisation exclusive de l'injection directe via constructeur pour les nouvelles implémentations
- Conservation du système Services pour la compatibilité, mais marqué comme déprécié
- Simplification des modules existants pour utiliser l'approche directe

## Changements apportés

1. **Simplification du module `services.lua`**
   - Suppression des fonctions non essentielles
   - Ajout d'un avertissement de dépréciation

2. **Simplification de `service_setup.lua`**
   - Suppression du système de factories
   - Marqué comme déprécié

3. **Mise à jour de `main.lua`**
   - Injection explicite des dépendances manquantes
   - Code plus clair et prévisible

4. **Mise à jour de `drag_drop.lua`**
   - Utilisation exclusive des dépendances injectées
   - Suppression des appels à `Services.get()`

5. **Documentation mise à jour dans `README.md`**
   - Description de l'approche d'injection directe
   - Exemple d'utilisation

## Bénéfices

- Code plus facile à comprendre et à maintenir
- Flux de données prévisible et traçable
- Réduction des erreurs potentielles liées à des dépendances manquantes
- Base solide pour les futures évolutions

## Tests

Cette modification a été testée localement pour vérifier qu'elle n'introduit pas de régressions.

## Note de migration

Pour le code futur, les développeurs doivent :
- Toujours utiliser l'injection via constructeur
- Ne plus utiliser `Services.get()` dans le nouveau code