### PR TITLE
Fix nil comparison error in garden_display.lua

### DIFF
--- a/src/ui/components/garden_display.lua
+++ b/src/ui/components/garden_display.lua
@@ -68,13 +68,14 @@ function GardenDisplay:draw()
     -- Dessiner les surbrillances pour le drag & drop si nécessaire
     if self.dragDrop and self.dragDrop:isDragging() then
         local mouseX, mouseY = love.mouse.getPosition()
-        mouseX = mouseX / (self.scaleManager.scale or 1)
-        mouseY = mouseY / (self.scaleManager.scale or 1)
+        mouseX = mouseX / (self.scaleManager and self.scaleManager.scale or 1)
+        mouseY = mouseY / (self.scaleManager and self.scaleManager.scale or 1)
         
         -- Vérifier quelle cellule est survolée
         local cellX, cellY = self:getCellAt(mouseX, mouseY)
         
-        if cellX >= 1 and cellX <= self.garden.width and cellY >= 1 and cellY <= self.garden.height then
+        -- FIX: Vérifier que cellX et cellY ne sont pas nil avant la comparaison
+        if cellX and cellY and cellX >= 1 and cellX <= self.garden.width and cellY >= 1 and cellY <= self.garden.height then
             -- Dessiner la surbrillance sur la cellule ciblée
             local cellScreenX, cellScreenY = self:getCellCoordinates(cellX, cellY)
             


### PR DESCRIPTION
## Description du problème
Lorsqu'un utilisateur clique sur une carte, une erreur se produit dans la fonction `draw()` du composant `garden_display.lua` à la ligne 77:

```
Error src/ui/components/garden_display.lua:77: attempt to compare number with nil
```

## Cause
Cette erreur se produit car la fonction `getCellAt()` peut retourner `nil, nil` si la souris est en dehors des limites valides du jardin. Dans la fonction `draw()`, les valeurs retournées `cellX` et `cellY` sont directement utilisées dans une comparaison numérique sans vérifier au préalable si elles sont nil.

## Solution
La correction ajoute une vérification supplémentaire pour s'assurer que `cellX` et `cellY` ne sont pas `nil` avant de les comparer à des valeurs numériques:

```lua
-- Avant:
if cellX >= 1 and cellX <= self.garden.width and cellY >= 1 and cellY <= self.garden.height then

-- Après:
if cellX and cellY and cellX >= 1 and cellX <= self.garden.width and cellY >= 1 and cellY <= self.garden.height then
```

J'ai également ajouté une vérification similaire pour `self.scaleManager` quelques lignes plus haut pour éviter d'éventuels problèmes similaires.

## Tests effectués
La modification a été testée en simulant le comportement qui déclenchait l'erreur. La vérification supplémentaire permet maintenant d'éviter l'erreur de comparaison avec `nil`.