### PR TITLE
Fix: Protection contre les nil values dans les composants

### DIFF
--- a/src/components/card_component.lua
+++ b/src/components/card_component.lua
@@ -1,0 +1,9 @@
+local CardComponent = Class('CardComponent')
+
+function CardComponent:initialize(card)
+    self.card = card or {
+        type = "plant"
+    }
+end
+
+return CardComponent

--- a/src/components/game_state_component.lua
+++ b/src/components/game_state_component.lua
@@ -1,0 +1,16 @@
+local GameStateComponent = Class('GameStateComponent')
+
+function GameStateComponent:initialize(state)
+    self.state = state or {
+        currentTurn = 1,
+        garden = {},
+        deck = {},
+        hand = {}
+    }
+    
+    if not self.state.garden then self.state.garden = {} end
+    if not self.state.deck then self.state.deck = {} end
+    if not self.state.hand then self.state.hand = {} end
+end
+
+return GameStateComponent

--- a/src/components/garden_component.lua
+++ b/src/components/garden_component.lua
@@ -1,0 +1,27 @@
+local GardenComponent = Class('GardenComponent')
+
+function GardenComponent:initialize(garden)
+    self.garden = garden or {
+        width = 3,
+        height = 2,
+        grid = {},
+        plantCount = 0
+    }
+    
+    if not self.garden.grid then
+        self.garden.grid = {}
+        for y = 1, self.garden.height do
+            self.garden.grid[y] = {}
+        end
+    end
+end
+
+function GardenComponent:getCell(x, y)
+    if y < 1 or y > #self.garden.grid or x < 1 or not self.garden.grid[y][x] then
+        return nil
+    end
+    
+    return self.garden.grid[y][x]
+end
+
+return GardenComponent

--- a/src/components/plant_component.lua
+++ b/src/components/plant_component.lua
@@ -1,0 +1,11 @@
+local PlantComponent = Class('PlantComponent')
+
+function PlantComponent:initialize(plant)
+    self.plant = plant or {
+        growthStage = "seed",
+        accumulatedSun = 0,
+        accumulatedRain = 0
+    }
+end
+
+return PlantComponent


### PR DESCRIPTION
## Problème identifié
Les composants (notamment garden_component) génèrent des erreurs du type `attempt to index field garden (a nil value)` lors du lancement du jeu, car ils tentent d'accéder à des objets non initialisés.

## Solution appliquée
Cette PR applique une solution minimaliste suivant le principe KISS:

1. **Initialisation par défaut** des objets principaux dans chaque composant
2. **Valeurs minimales** pour éviter les erreurs nil sans surcharger le code
3. **Protection simple** dans la méthode getCell() de GardenComponent
4. **Initialisation de la grille** du jardin pour éviter les erreurs d'indexation

## Composants modifiés
- garden_component.lua
- plant_component.lua 
- card_component.lua
- game_state_component.lua

Les modifications sont minimales et n'introduisent pas de vérifications conditionnelles supplémentaires dans les autres méthodes pour garder le code simple et lisible.