### PR TITLE
Fix: Cartes invisibles dans la main du joueur

### DIFF
--- a/src/systems/card_system.lua
+++ b/src/systems/card_system.lua
@@ -34,6 +34,7 @@ function CardSystem:initializeDeck()
             id = "brassika_" .. i,
             type = GameConfig.CARD_TYPE.PLANT,
             family = GameConfig.PLANT_FAMILY.BRASSIKA,
+            name = "Brassika",  -- Ajout du nom pour l'affichage
             color = {0.7, 0.85, 0.7}, -- Vert pâle
             sunToSprout = 3,
             rainToSprout = 4,
@@ -54,6 +55,7 @@ function CardSystem:initializeDeck()
             id = "solana_" .. i,
             type = GameConfig.CARD_TYPE.PLANT,
             family = GameConfig.PLANT_FAMILY.SOLANA,
+            name = "Solana",    -- Ajout du nom pour l'affichage
             color = {0.9, 0.7, 0.5}, -- Orange pâle
             sunToSprout = 5,
             rainToSprout = 3,


### PR DESCRIPTION
## Problème identifié
La main du joueur est vide malgré les cartes initialisées correctement dans card_system.lua. Après analyse, c'est parce que le hand_component.lua affiche "Main vide" quand les cartes n'ont pas de "name" défini.

## Solution appliquée
Cette PR contient une correction minimale qui ajoute les noms de cartes dans card_system.lua lors de l'initialisation:

```lua
local card = {
    id = "brassika_" .. i,
    type = GameConfig.CARD_TYPE.PLANT,
    family = GameConfig.PLANT_FAMILY.BRASSIKA,
    name = "Brassika",  -- Ajout du nom pour l'affichage
    ...
}
```

Les modifications sont limitées à:
1. Ajouter la propriété "name" à chaque carte Brassika
2. Ajouter la propriété "name" à chaque carte Solana

## Approche KISS
La solution est minimaliste et résout directement le problème sans ajouter de complexité:
- Un seul fichier modifié
- Deux lignes modifiées avec des commentaires explicatifs
- Aucune modification de structure ou d'API
- Pas de changement dans la logique de rendu

Cette correction permettra l'affichage correct des cartes tout en préservant la simplicité du code.