### PR TITLE
Fix: Élimination de la double initialisation de cartes

### DIFF
--- a/src/components/game_state_component.lua
+++ b/src/components/game_state_component.lua
@@ -9,53 +9,8 @@ function GameStateComponent:initialize(state)
     }
     
     if not self.state.garden then self.state.garden = {} end
-    
-    -- Initialize deck with starter cards if empty
-    if not self.state.deck or #self.state.deck == 0 then
-        self.state.deck = self:createStarterDeck()
-    end
-    
-    -- Initialize hand with cards from deck if empty
-    if not self.state.hand or #self.state.hand == 0 then
-        self.state.hand = {}
-        for i = 1, math.min(5, #self.state.deck) do
-            table.insert(self.state.hand, table.remove(self.state.deck, 1))
-        end
-    end
-end
-
-function GameStateComponent:createStarterDeck()
-    local deck = {}
-    
-    -- Add Brassika cards (résistant au gel, croissance rapide)
-    for i = 1, 4 do
-        table.insert(deck, {
-            id = "brassika_" .. i,
-            type = "plant",
-            family = "Brassika",
-            name = "Brassika",
-            color = "Green"
-        })
-    end
-    
-    -- Add Solana cards (vulnérable au gel, grands besoins en soleil, score élevé)
-    for i = 1, 3 do
-        table.insert(deck, {
-            id = "solana_" .. i,
-            type = "plant",
-            family = "Solana",
-            name = "Solana",
-            color = "Red"
-        })
-    end
-    
-    -- Shuffle the deck
-    for i = #deck, 2, -1 do
-        local j = math.random(i)
-        deck[i], deck[j] = deck[j], deck[i]
-    end
-    
-    return deck
+    if not self.state.deck then self.state.deck = {} end
+    if not self.state.hand then self.state.hand = {} end
 end
 
 return GameStateComponent

--- a/src/systems/card_system.lua
+++ b/src/systems/card_system.lua
@@ -34,6 +34,7 @@ function CardSystem:initializeDeck()
             id = "brassika_" .. i,
             type = GameConfig.CARD_TYPE.PLANT,
             family = GameConfig.PLANT_FAMILY.BRASSIKA,
+            name = "Brassika", -- Nom pour l'affichage
             color = {0.7, 0.85, 0.7}, -- Vert pâle
             sunToSprout = 3,
             rainToSprout = 4,
@@ -54,6 +55,7 @@ function CardSystem:initializeDeck()
             id = "solana_" .. i,
             type = GameConfig.CARD_TYPE.PLANT,
             family = GameConfig.PLANT_FAMILY.SOLANA,
+            name = "Solana", -- Nom pour l'affichage
             color = {0.9, 0.7, 0.5}, -- Orange pâle
             sunToSprout = 5,
             rainToSprout = 3,


### PR DESCRIPTION
## Problème identifié
Après les précédentes PR, le code se retrouve avec deux initialisations du deck de cartes qui se font en parallèle:
1. Dans `card_system.lua`, méthode `initializeDeck()`
2. Dans `game_state_component.lua`, méthode `createStarterDeck()`

Cette duplication crée potentiellement des problèmes de cohérence et ajoute du code inutile.

## Solution appliquée
Cette PR:
1. Ajoute les propriétés `name` aux cartes dans `card_system.lua` pour permettre l'affichage correct
2. Supprime la méthode `createStarterDeck()` dans `game_state_component.lua`
3. Simplifie l'initialisation du composant pour éviter toute duplication de code

## Approche KISS
Cette solution est la plus simple possible:
- Suppression du code redondant
- Conservation d'une seule source de vérité pour l'initialisation des cartes
- Modification minimale qui corrige le problème à la racine

Cette approche permet aussi d'éviter les problèmes potentiels futurs liés à la maintenance de deux systèmes de cartes parallèles.