### PR TITLE
Fix: Mise à jour du potager après drag & drop

### DIFF
--- a/src/ui/drag_drop.lua
+++ b/src/ui/drag_drop.lua
@@ -140,6 +140,12 @@ function DragDrop:stopDrag(garden)
                 if not garden.grid[y][x].plant then
                     if self.cardIndex and self.dependencies.cardSystem then
                         placed = self.dependencies.cardSystem:playCard(self.cardIndex, garden, x, y)
+                        
+                        -- CORRECTION: Forcer la mise à jour du GardenComponent après placement
+                        if placed and uiManager then
+                            print("Plante placée en (", x, ",", y, ") - Mise à jour du composant garden")
+                            uiManager:updateComponent("garden")
+                        end
                     end
                 end
                 


### PR DESCRIPTION
## Problème identifié
Après avoir corrigé l'affichage des cartes dans la main du joueur, un nouveau problème est apparu : les plantes ne sont pas visibles dans le potager après l'opération de drag & drop.

## Causes
1. Le `GardenComponent` souffre du même problème d'héritage que `HandComponent`
2. Le système de drag & drop ne force pas une mise à jour du composant potager après placement
3. La méthode `refreshGarden` n'était pas implémentée explicitement

## Solution
Cette PR applique une solution similaire à celle utilisée pour HandComponent:

1. **Réimplémentation du GardenComponent sans héritage par setmetatable**:
   - Initialisation explicite de tous les attributs requis
   - Accès direct aux paramètres (`params.garden` au lieu de `params.model`)
   - Implémentation des méthodes manquantes de ComponentBase

2. **Mise à jour forcée du jardin après placement**:
   - Appel explicite à `uiManager:updateComponent("garden")` dans DragDrop.stopDrag
   - Implémentation complète de la méthode `refreshGarden`
   - Meilleure gestion des erreurs si garden est nil

3. **Debug amélioré**:
   - Messages dans la console pour suivre le cycle de vie des plantes
   - Vérifications de type pour éviter les erreurs sur les propriétés

Cette approche KISS corrige le problème de fond en simplifiant l'architecture.