### PR TITLE
Add GameLevel component to organize level elements

### DIFF
--- a/src/core/Game.lua
+++ b/src/core/Game.lua
@@ -11,13 +11,7 @@ Game.__index = Game
 
 -- Import components
 local GameState = require("src/core/GameState")
-local Garden = require("src/elements/board/Garden")
-local CardHand = require("src/elements/cards/CardHand")
-local Deck = require("src/elements/cards/Deck")
-local RoundBoard = require("src/elements/board/RoundBoard")
-local ScoreBoard = require("src/elements/board/ScoreBoard")
-local SunDie = require("src/elements/dice/SunDie")
-local RainDie = require("src/elements/dice/RainDie")
+local GameLevel = require("src/elements/level/GameLevel")
 local color = require("utils/convertColor")
 
 -- Constructor
@@ -27,14 +21,8 @@ function Game:new()
     -- Game state
     self.gameState = GameState:new()
     
-    -- Game components
-    self.garden = nil
-    self.cardHand = nil
-    self.deck = nil
-    self.roundBoard = nil
-    self.scoreBoard = nil
-    self.sunDie = nil
-    self.rainDie = nil
+    -- Game level
+    self.currentLevel = nil
     
     -- Screen dimensions
     self.width = DEFAULT_WINDOW_WIDTH
@@ -45,23 +33,15 @@ end
 
 -- Initialize game components
 function Game:initialize()
-    -- Create game components
-    self.garden = Garden:new(3, 2) -- 3x2 grid
-    self.cardHand = CardHand:new(5) -- 5 cards max
-    self.deck = Deck:new()
-    self.roundBoard = RoundBoard:new()
-    self.scoreBoard = ScoreBoard:new()
-    self.sunDie = SunDie:new()
-    self.rainDie = RainDie:new()
+    -- Create game level
+    self.currentLevel = GameLevel:new()
+    self.currentLevel:initialize("normal")
     
     -- Place components on screen
     self:placeComponents()
     
     -- Initialize game state
     self.gameState:changeState("gameplay")
-    
-    -- Deal initial cards
-    self.cardHand:drawCards(self.deck, 5)
 end
 
 -- Position components on screen
@@ -69,21 +49,8 @@ function Game:placeComponents()
     -- Get screen dimensions
     self.width, self.height = love.graphics.getDimensions()
     
-    -- Center the garden
-    self.garden:setPosition(self.width / 2, self.height / 2)
-    
-    -- Place score in top left
-    self.scoreBoard:setPosition(20, 20)
-    
-    -- Place round board in top center
-    self.roundBoard:setPosition(self.width / 2, 50)
-    
-    -- Place dice below round board
-    self.sunDie:setPosition(self.width / 2 - 30, 120)
-    self.rainDie:setPosition(self.width / 2 + 30, 120)
-    
-    -- Place card hand at bottom
-    self.cardHand:setPosition(self.width / 2, self.height - 100)
+    -- Position level components
+    self.currentLevel:setPosition(self.width, self.height)
 end
 
 -- Update game state and components
@@ -92,13 +59,8 @@ function Game:update(dt)
     local currentState = self.gameState:getCurrentState()
     
     if currentState == "gameplay" then
-        -- Update all components
-        self.garden:update(dt)
-        self.cardHand:update(dt)
-        self.roundBoard:update(dt)
-        self.sunDie:update(dt)
-        self.rainDie:update(dt)
-        self.scoreBoard:update(dt)
+        -- Update level
+        self.currentLevel:update(dt)
     end
     
     -- Handle window resize
@@ -122,13 +84,8 @@ function Game:draw()
     local currentState = self.gameState:getCurrentState()
     
     if currentState == "gameplay" then
-        -- Draw all components
-        self.garden:draw()
-        self.cardHand:draw()
-        self.roundBoard:draw()
-        self.sunDie:draw()
-        self.rainDie:draw()
-        self.scoreBoard:draw()
+        -- Draw level
+        self.currentLevel:draw()
     end
 end
 
@@ -136,6 +93,9 @@ end
 function Game:keypressed(key)
     if key == "escape" then
         love.event.quit()
+    elseif key == "n" and self.gameState:getCurrentState() == "gameplay" then
+        -- Debug: advance to next round
+        self.currentLevel:nextRound()
     end
 end
 
@@ -145,18 +105,8 @@ function Game:mousepressed(x, y, button)
     local currentState = self.gameState:getCurrentState()
     
     if currentState == "gameplay" then
-        -- Check if clicked on garden
-        self.garden:mousepressed(x, y, button)
-        
-        -- Check if clicked on card
-        self.cardHand:mousepressed(x, y, button)
-        
-        -- Check if clicked on dice
-        self.sunDie:mousepressed(x, y, button)
-        self.rainDie:mousepressed(x, y, button)
-        
-        -- Check if clicked on round board
-        self.roundBoard:mousepressed(x, y, button)
+        -- Forward to level
+        self.currentLevel:mousepressed(x, y, button)
     end
 end
 
@@ -166,11 +116,8 @@ function Game:mousereleased(x, y, button)
     local currentState = self.gameState:getCurrentState()
     
     if currentState == "gameplay" then
-        -- Check if released on garden
-        self.garden:mousereleased(x, y, button)
-        
-        -- Check if released on card
-        self.cardHand:mousereleased(x, y, button)
+        -- Forward to level
+        self.currentLevel:mousereleased(x, y, button)
     end
 end
 

--- a/src/elements/level/GameLevel.lua
+++ b/src/elements/level/GameLevel.lua
@@ -1,0 +1,176 @@
+-- src/elements/level/GameLevel.lua
+
+-- Constants
+local DEFAULT_DIFFICULTY = "normal"   -- Default difficulty level
+local TARGET_SCORES = {               -- Target scores for different difficulties
+    easy = 80,
+    normal = 100,
+    hard = 120
+}
+
+-- GameLevel contains all elements of a playable level
+local GameLevel = {}
+GameLevel.__index = GameLevel
+
+-- Import components
+local Garden = require("src/elements/board/Garden")
+local CardHand = require("src/elements/cards/CardHand")
+local Deck = require("src/elements/cards/Deck")
+local RoundBoard = require("src/elements/board/RoundBoard")
+local ScoreBoard = require("src/elements/board/ScoreBoard")
+local SunDie = require("src/elements/dice/SunDie")
+local RainDie = require("src/elements/dice/RainDie")
+
+-- Constructor
+function GameLevel:new()
+    local self = setmetatable({}, GameLevel)
+    
+    -- Level components
+    self.garden = nil
+    self.cardHand = nil
+    self.deck = nil
+    self.roundBoard = nil
+    self.scoreBoard = nil
+    self.sunDie = nil
+    self.rainDie = nil
+    
+    -- Level state
+    self.isActive = false
+    self.difficulty = DEFAULT_DIFFICULTY
+    
+    return self
+end
+
+-- Initialize level components
+function GameLevel:initialize(difficulty)
+    self.difficulty = difficulty or DEFAULT_DIFFICULTY
+    
+    -- Create level components
+    self.garden = Garden:new(3, 2) -- 3x2 grid
+    self.cardHand = CardHand:new(5) -- 5 cards max
+    self.deck = Deck:new()
+    self.roundBoard = RoundBoard:new()
+    self.scoreBoard = ScoreBoard:new()
+    self.sunDie = SunDie:new()
+    self.rainDie = RainDie:new()
+    
+    -- Set target score based on difficulty
+    local targetScore = TARGET_SCORES[self.difficulty] or TARGET_SCORES.normal
+    self.scoreBoard:setTarget(targetScore)
+    
+    -- Deal initial cards
+    self.cardHand:drawCards(self.deck, 5)
+    
+    -- Activate level
+    self.isActive = true
+end
+
+-- Position components on screen
+function GameLevel:setPosition(width, height)
+    -- Center the garden
+    self.garden:setPosition(width / 2, height / 2)
+    
+    -- Place score in top left
+    self.scoreBoard:setPosition(20, 20)
+    
+    -- Place round board in top center
+    self.roundBoard:setPosition(width / 2, 50)
+    
+    -- Place dice below round board
+    self.sunDie:setPosition(width / 2 - 30, 120)
+    self.rainDie:setPosition(width / 2 + 30, 120)
+    
+    -- Place card hand at bottom
+    self.cardHand:setPosition(width / 2, height - 100)
+end
+
+-- Update level components
+function GameLevel:update(dt)
+    if not self.isActive then return end
+    
+    -- Update all components
+    self.garden:update(dt)
+    self.cardHand:update(dt)
+    self.roundBoard:update(dt)
+    self.sunDie:update(dt)
+    self.rainDie:update(dt)
+    self.scoreBoard:update(dt)
+    
+    -- Check if level is completed
+    if self.scoreBoard:isTargetReached() then
+        -- Handle level completion
+    end
+end
+
+-- Draw level components
+function GameLevel:draw()
+    if not self.isActive then return end
+    
+    -- Draw all components
+    self.garden:draw()
+    self.cardHand:draw()
+    self.roundBoard:draw()
+    self.sunDie:draw()
+    self.rainDie:draw()
+    self.scoreBoard:draw()
+end
+
+-- Handle mouse press events
+function GameLevel:mousepressed(x, y, button)
+    if not self.isActive then return end
+    
+    -- Check if clicked on garden
+    self.garden:mousepressed(x, y, button)
+    
+    -- Check if clicked on card
+    self.cardHand:mousepressed(x, y, button)
+    
+    -- Check if clicked on dice
+    self.sunDie:mousepressed(x, y, button)
+    self.rainDie:mousepressed(x, y, button)
+    
+    -- Check if clicked on round board
+    self.roundBoard:mousepressed(x, y, button)
+end
+
+-- Handle mouse release events
+function GameLevel:mousereleased(x, y, button)
+    if not self.isActive then return end
+    
+    -- Check if released on garden
+    self.garden:mousereleased(x, y, button)
+    
+    -- Check if released on card
+    self.cardHand:mousereleased(x, y, button)
+end
+
+-- Advance to next round
+function GameLevel:nextRound()
+    if not self.isActive then return end
+    
+    -- Get current round before advancing
+    local currentRound = self.roundBoard:getCurrentRound()
+    
+    -- Advance round board
+    local nextRound = self.roundBoard:nextRound()
+    if not nextRound then
+        -- No more rounds, end level
+        self.isActive = false
+        return false
+    end
+    
+    -- Roll dice for new round
+    local season = nextRound.season
+    self.sunDie:rollForSeason(season)
+    self.rainDie:rollForSeason(season)
+    
+    -- Draw a new card
+    local card = self.deck:drawCard()
+    if card then
+        self.cardHand:addCard(card)
+    end
+    
+    return true
+end
+
+return GameLevel


### PR DESCRIPTION
This PR adds a GameLevel component to organize all of the level-related elements in one place, following the KISS principle.

## Changes made:

1. **Added GameLevel component**
   - Created `src/elements/level/GameLevel.lua` to contain all level elements
   - Keeps elements organized logically within a single container
   - Handles initializing, positioning, updating, and drawing all level components
   - Simplifies state management with a simple `isActive` flag
   - Adds support for difficulty levels with different target scores

2. **Simplified Game.lua**
   - Reduced complexity by delegating level management to GameLevel
   - Removed direct references to individual components
   - Made Game.lua focus on high-level game flow and state management
   - Added a debug key 'n' to advance to next round for testing

3. **Architecture Benefits**
   - Better separation of concerns
   - Easier to manage and extend
   - More maintainable code structure
   - Reduced duplicate logic
   - More scalable for future development

The core functionality remains unchanged, but the code is now more organized and follows better architectural practices while keeping things simple.