### PR TITLE
Correction du positionnement vertical des cartes en main

### DIFF
--- a/src/elements/cards/CardHand.lua
+++ b/src/elements/cards/CardHand.lua
@@ -6,6 +6,7 @@ local CARD_SPACING = 30                -- Horizontal spacing between cards
 local CARD_ARC_RADIUS = 400            -- Radius of the arc for card layout
 local CARD_ARC_ANGLE = math.pi / 4     -- Angle of the arc (45 degrees)
 local CARD_ROTATION_MAX = math.pi / 12 -- Maximum card rotation (15 degrees)
+local CARD_Y_FACTOR = 8                -- Facteur de réduction pour la position Y (évite de placer les cartes trop haut)
 
 -- CardHand manages the player's current hand of cards
 local CardHand = {}
@@ -80,7 +81,8 @@ function CardHand:arrangeCards()
 
         -- Calculate position on arc
         local cardX = self.x + math.sin(angle) * CARD_ARC_RADIUS
-        local cardY = self.y - math.cos(angle) * CARD_ARC_RADIUS
+        -- Réduction du facteur vertical pour garder les cartes plus proches de self.y
+        local cardY = self.y - math.cos(angle) * (CARD_ARC_RADIUS / CARD_Y_FACTOR)
 
         -- Position card
         card:setPosition(cardX, cardY)


### PR DESCRIPTION
## Description du problème
Les cartes en main sont actuellement positionnées trop haut sur l'écran (premier tiers), alors qu'elles devraient apparaître en bas de l'écran selon le wireframe et les spécifications.

## Cause du problème
Dans la fonction `arrangeCards()` du fichier `CardHand.lua`, le calcul des positions y des cartes utilise :
```lua
local cardY = self.y - math.cos(angle) * CARD_ARC_RADIUS
```

Ce calcul place les cartes très loin au-dessus de la position `self.y` définie, car la composante cosinus avec le grand rayon d'arc (400 pixels) crée un déplacement vertical trop important.

## Solution implémentée
La solution consiste à réduire l'impact du rayon de l'arc sur la composante verticale :

```lua
local cardY = self.y - math.cos(angle) * (CARD_ARC_RADIUS / CARD_Y_FACTOR)
```

J'ai introduit un facteur de réduction (`CARD_Y_FACTOR = 8`) qui permet de conserver l'effet d'arc tout en maintenant les cartes plus proches de la position `self.y` initialement définie.

## Résultat attendu
Les cartes seront désormais positionnées correctement en bas de l'écran tout en conservant leur disposition en arc de cercle, conformément au wireframe de l'interface.