### PR TITLE
Correction du système de drag and drop

### DIFF
--- a/src/elements/cards/CardHand.lua
+++ b/src/elements/cards/CardHand.lua
@@ -77,6 +77,11 @@ function CardHand:arrangeCards()
 
     -- Position each card along the arc
     for i, card in ipairs(self.cards) do
+        -- Si la carte est en cours de drag, ne pas la repositionner
+        if card.isDragging then
+            goto continue
+        end
+        
         local angle = startAngle + (i - 1) * angleStep
 
         -- Calculate position on arc
@@ -89,6 +94,8 @@ function CardHand:arrangeCards()
 
         -- Rotate card to face outward from arc center
         card:setRotation(angle)
+        
+        ::continue::
     end
 end
 
@@ -108,9 +115,21 @@ end
 
 -- Draw hand
 function CardHand:draw()
-    -- Draw each card from bottom to top
+    -- Draw each card in order, sauf celle en cours de drag qui sera dessinée en dernier
+    local draggedCard = nil
+    
     for i = 1, #self.cards do
-        self.cards[i]:draw()
+        -- Si la carte est en cours de drag, la garder pour la fin
+        if self.cards[i].isDragging then
+            draggedCard = self.cards[i]
+        else
+            self.cards[i]:draw()
+        end
+    end
+    
+    -- Dessiner la carte en cours de drag en dernier pour qu'elle soit au dessus
+    if draggedCard then
+        draggedCard:draw()
     end
 end
 
@@ -119,11 +138,19 @@ function CardHand:update(dt)
     for _, card in ipairs(self.cards) do
         card:update(dt)
     end
-end
-
--- Handle mouse release
-function CardHand:mousereleased(x, y, button)
-    -- To be implemented later for drag & drop
+    
+    -- Réarranger les cartes (sauf si une est en cours de drag)
+    local needRearrange = true
+    for _, card in ipairs(self.cards) do
+        if card.isDragging then
+            needRearrange = false
+            break
+        end
+    end
+    
+    if needRearrange then
+        self:arrangeCards()
+    end
 end
 
 return CardHand


### PR DESCRIPTION
Cette PR corrige le problème du système de drag and drop qui ne suivait pas correctement la souris lorsqu'elle se déplaçait rapidement.

## Changements
- Ajout d'un état `isDragging` distinct de `isSelected` dans la classe `Card`
- Modification de la logique de déplacement pour faire suivre la carte à la position absolue de la souris avec un offset
- Amélioration de la méthode `mousemoved` dans `GameLevel` pour prioriser le déplacement des cartes en cours de drag
- Mise à jour de `CardHand` pour éviter de repositionner les cartes en cours de drag et les afficher en dernier (au-dessus)

## Comment tester
1. Sélectionner une carte et la faire glisser rapidement
2. Vérifier que la carte suit correctement le mouvement de la souris, même lors de déplacements rapides
3. Vérifier que la carte revient à sa position initiale si relâchée en dehors d'une cellule valide

## Notes
Dans le futur, on pourrait ajouter une visualisation de la cellule cible pour mieux indiquer où la carte va être déposée.