### PR TITLE
Correction de la syntaxe de couleur rouge dans outlineColors

### DIFF
--- a/src/elements/cards/Card.lua
+++ b/src/elements/cards/Card.lua
@@ -17,7 +17,7 @@ local backgroundColors = {
     blue = '#5b5bf5',
 }
 local outlineColors = {
-    red = '##ba0000',
+    red = '#ba0000',
     green = '#00ba00',
     blue = '#0000ba',
 }


### PR DESCRIPTION
Cette PR corrige l'erreur présente à la ligne 123 du fichier `Card.lua` dans la branche `card-details`.

## Problème

La définition de la couleur rouge dans la table `outlineColors` contenait une erreur syntaxique avec un double dièse (`##`) au lieu d'un seul, ce qui causait une erreur lors de l'appel à `self.color.hex(self.outlineColor)` dans la fonction `Card:draw()`.

## Correction

Modification de :
```lua
red = '##ba0000',
```

En :
```lua
red = '#ba0000',
```

Cette correction permettra aux cartes avec des bordures rouges de s'afficher correctement.